### PR TITLE
chore: add Kraken game #71 (2025.03.22) data

### DIFF
--- a/data/NHL - National Hockey League/2024-25/regular-season/20250322-SEA-vs-EDM-2024021116.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250322-SEA-vs-EDM-2024021116.json
@@ -1,0 +1,7509 @@
+{
+    "id": 2024021116,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-03-22",
+    "venue": {
+        "default": "Rogers Place"
+    },
+    "venueLocation": {
+        "default": "Edmonton"
+    },
+    "startTimeUTC": "2025-03-23T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-06:00",
+    "tvBroadcasts": [
+        {
+            "id": 4,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "CBC",
+            "sequenceNumber": 25
+        },
+        {
+            "id": 286,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "CITY",
+            "sequenceNumber": 26
+        },
+        {
+            "id": 282,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "SN",
+            "sequenceNumber": 101
+        },
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 552,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KING 5",
+            "sequenceNumber": 340
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 4,
+        "sog": 31,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 22,
+        "commonName": {
+            "default": "Oilers"
+        },
+        "abbrev": "EDM",
+        "score": 5,
+        "sog": 29,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/EDM_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/EDM_dark.svg",
+        "placeName": {
+            "default": "Edmonton"
+        },
+        "placeNameWithPreposition": {
+            "default": "Edmonton",
+            "fr": "d'Edmonton"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 52,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 51,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 104,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:33",
+            "timeRemaining": "19:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 14,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 115,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478916
+            }
+        },
+        {
+            "eventId": 114,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:12",
+            "timeRemaining": "18:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 24,
+            "details": {
+                "xCoord": 28,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475218,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 0,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 123,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:26",
+            "timeRemaining": "18:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 25,
+            "details": {
+                "xCoord": 89,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 124,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:15",
+            "timeRemaining": "17:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 33,
+            "details": {
+                "xCoord": 49,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 0,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:41",
+            "timeRemaining": "17:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 44,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:41",
+            "timeRemaining": "17:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 45,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:16",
+            "timeRemaining": "16:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 46,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 42,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8477498
+            }
+        },
+        {
+            "eventId": 138,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:28",
+            "timeRemaining": "16:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 50,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 32,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:09",
+            "timeRemaining": "15:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 56,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 1,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 57,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8475218,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 168,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:49",
+            "timeRemaining": "15:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 67,
+            "details": {
+                "xCoord": 33,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479372,
+                "hitteePlayerId": 8479442
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:00",
+            "timeRemaining": "15:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 68,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:17",
+            "timeRemaining": "14:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 70,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:32",
+            "timeRemaining": "14:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 71,
+            "details": {
+                "xCoord": 49,
+                "yCoord": 24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481554,
+                "shootingPlayerId": 8476967,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 169,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 79,
+            "details": {
+                "xCoord": 46,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 179,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:01",
+            "timeRemaining": "12:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 89,
+            "details": {
+                "xCoord": -53,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "snap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 200,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:02",
+            "timeRemaining": "12:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 90,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 180,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:05",
+            "timeRemaining": "12:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 91,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:24",
+            "timeRemaining": "12:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 101,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8476967
+            }
+        },
+        {
+            "eventId": 191,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:00",
+            "timeRemaining": "12:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 103,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 199,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:26",
+            "timeRemaining": "11:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 111,
+            "details": {
+                "xCoord": -60,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477498,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 251,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:36",
+            "timeRemaining": "11:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 112,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478013,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:56",
+            "timeRemaining": "11:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 113,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477498,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 280,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:00",
+            "timeRemaining": "11:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 114,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8476454
+            }
+        },
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 116,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 118,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:09",
+            "timeRemaining": "10:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 119,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477498,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 265,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 123,
+            "details": {
+                "xCoord": 67,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8470621
+            }
+        },
+        {
+            "eventId": 263,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:41",
+            "timeRemaining": "10:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 126,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8474641,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 273,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:48",
+            "timeRemaining": "10:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 127,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:00",
+            "timeRemaining": "10:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 131,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 268,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 132,
+            "details": {
+                "xCoord": -70,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475218,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 300,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:53",
+            "timeRemaining": "09:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 140,
+            "details": {
+                "xCoord": 16,
+                "yCoord": -21,
+                "zoneCode": "N",
+                "playerId": 8479442,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 352,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:16",
+            "timeRemaining": "08:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 149,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8478013
+            }
+        },
+        {
+            "eventId": 286,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:17",
+            "timeRemaining": "08:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 150,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477406,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 358,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:33",
+            "timeRemaining": "08:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 153,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483497
+            }
+        },
+        {
+            "eventId": 289,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 156,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 3,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:52",
+            "timeRemaining": "08:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 158,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 3,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 359,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:02",
+            "timeRemaining": "07:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 162,
+            "details": {
+                "xCoord": -45,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8480803
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:23",
+            "timeRemaining": "07:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 166,
+            "details": {
+                "xCoord": 16,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8475218,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 351,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:36",
+            "timeRemaining": "07:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 168,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 3,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 355,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:38",
+            "timeRemaining": "07:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 169,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8476457,
+                "drawnByPlayerId": 8476454,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:38",
+            "timeRemaining": "07:22",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 171,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 55,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:38",
+            "timeRemaining": "07:22",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 174,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 364,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:48",
+            "timeRemaining": "06:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 178,
+            "details": {
+                "xCoord": 37,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 372,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:30",
+            "timeRemaining": "05:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 186,
+            "details": {
+                "xCoord": 55,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8474641,
+                "scoringPlayerTotal": 9,
+                "assist1PlayerId": 8475218,
+                "assist1PlayerTotal": 22,
+                "assist2PlayerId": 8477498,
+                "assist2PlayerTotal": 22,
+                "eventOwnerTeamId": 22,
+                "goalieInNetId": 8478916,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-henrique-scores-ppg-against-joey-daccord-6370411688112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-henrique-marque-un-but-en-a-n-contre-joey-daccord-6370410449112",
+                "highlightClip": 6370411688112,
+                "highlightClipFr": 6370410449112,
+                "discreteClip": 6370409042112,
+                "discreteClipFr": 6370410803112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev372.json"
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:30",
+            "timeRemaining": "05:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 190,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 384,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:58",
+            "timeRemaining": "05:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 191,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 380,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 193,
+            "details": {
+                "xCoord": -35,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8476967,
+                "drawnByPlayerId": 8475768,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 195,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 56,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 198,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:23",
+            "timeRemaining": "04:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 199,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 57,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:23",
+            "timeRemaining": "04:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 200,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 386,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:46",
+            "timeRemaining": "04:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:48",
+            "timeRemaining": "04:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 202,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 387,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 203,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8481554,
+                "scoringPlayerTotal": 12,
+                "assist1PlayerId": 8482665,
+                "assist1PlayerTotal": 22,
+                "assist2PlayerId": 8483497,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479973,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-kakko-scores-ppg-against-stuart-skinner-6370410120112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-kakko-marque-un-but-en-a-n-contre-stuart-skinner-6370410424112",
+                "highlightClip": 6370410120112,
+                "highlightClipFr": 6370410424112,
+                "discreteClip": 6370411404112,
+                "discreteClipFr": 6370409437112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev387.json"
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 207,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477955,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 405,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 208,
+            "details": {
+                "xCoord": -99,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477955
+            }
+        },
+        {
+            "eventId": 393,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:29",
+            "timeRemaining": "03:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 211,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479442,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 403,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:02",
+            "timeRemaining": "02:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 220,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:03",
+            "timeRemaining": "02:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 221,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:03",
+            "timeRemaining": "02:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 224,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8474586,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 409,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 226,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 6,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 410,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 227,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8479368,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 421,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:47",
+            "timeRemaining": "02:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 228,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 425,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:50",
+            "timeRemaining": "02:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 230,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8479368
+            }
+        },
+        {
+            "eventId": 427,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:52",
+            "timeRemaining": "02:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 231,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478407,
+                "hitteePlayerId": 8477953
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 232,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 420,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:24",
+            "timeRemaining": "01:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 240,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:25",
+            "timeRemaining": "01:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 241,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:26",
+            "timeRemaining": "01:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 242,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:26",
+            "timeRemaining": "01:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 243,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:46",
+            "timeRemaining": "01:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 245,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 60,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:46",
+            "timeRemaining": "01:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 248,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477406,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 432,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:57",
+            "timeRemaining": "01:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 249,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8475784,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 428,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:03",
+            "timeRemaining": "00:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 250,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479442,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 9,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 429,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:05",
+            "timeRemaining": "00:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 251,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8477406,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 431,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:22",
+            "timeRemaining": "00:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 252,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 263
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 268
+        },
+        {
+            "eventId": 61,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 271,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477406,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 453,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:18",
+            "timeRemaining": "19:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 272,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "playerId": 8474586,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 446,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:28",
+            "timeRemaining": "19:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 273,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 447,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:35",
+            "timeRemaining": "19:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 274,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 452,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:54",
+            "timeRemaining": "19:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 279,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 10,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 280,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 283,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 457,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:21",
+            "timeRemaining": "18:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 284,
+            "details": {
+                "xCoord": 58,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 463,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 288,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8474641,
+                "drawnByPlayerId": 8481554,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 292,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 467,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:49",
+            "timeRemaining": "18:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 293,
+            "details": {
+                "xCoord": 31,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:50",
+            "timeRemaining": "18:10",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 294,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:50",
+            "timeRemaining": "18:10",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 295,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8475768,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 469,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:55",
+            "timeRemaining": "18:05",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 296,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 205,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 298,
+            "details": {
+                "xCoord": -2,
+                "yCoord": -22,
+                "zoneCode": "N",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 479,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 300,
+            "details": {
+                "xCoord": 26,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8481617
+            }
+        },
+        {
+            "eventId": 480,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 308,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477498,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 482,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 312,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8476454,
+                "scoringPlayerTotal": 18,
+                "assist1PlayerId": 8477953,
+                "assist1PlayerTotal": 6,
+                "assist2PlayerId": 8477498,
+                "assist2PlayerTotal": 23,
+                "eventOwnerTeamId": 22,
+                "goalieInNetId": 8478916,
+                "awayScore": 1,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-nugent-hopkins-scores-goal-against-joey-daccord-6370410937112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-nugent-hopkins-marque-un-but-contre-joey-daccord-6370412401112",
+                "highlightClip": 6370410937112,
+                "highlightClipFr": 6370412401112,
+                "discreteClip": 6370410158112,
+                "discreteClipFr": 6370412604112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev482.json"
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 315,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478585,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 496,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:06",
+            "timeRemaining": "15:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 316,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 618,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:07",
+            "timeRemaining": "15:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 317,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8475218
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 318,
+            "details": {
+                "xCoord": 1,
+                "yCoord": -26,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "playerId": 8475786
+            }
+        },
+        {
+            "eventId": 609,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:22",
+            "timeRemaining": "15:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 320,
+            "details": {
+                "xCoord": 4,
+                "yCoord": 23,
+                "zoneCode": "N",
+                "playerId": 8475786,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 622,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:48",
+            "timeRemaining": "15:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 328,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 1,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 497,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:56",
+            "timeRemaining": "15:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 331,
+            "details": {
+                "xCoord": 72,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 500,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:05",
+            "timeRemaining": "14:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 332,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 624,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:22",
+            "timeRemaining": "14:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 336,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8479442
+            }
+        },
+        {
+            "eventId": 608,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 340,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 610,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:51",
+            "timeRemaining": "14:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 341,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8474586,
+                "shootingPlayerId": 8475784,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 619,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:32",
+            "timeRemaining": "13:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 348,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8478585,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:41",
+            "timeRemaining": "13:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 349,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 66,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:41",
+            "timeRemaining": "13:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 352,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8470621,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 631,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 503,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:49",
+            "timeRemaining": "13:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8475786,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:01",
+            "timeRemaining": "12:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 355,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8481554,
+                "scoringPlayerTotal": 13,
+                "assist1PlayerId": 8483497,
+                "assist1PlayerTotal": 2,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479973,
+                "awayScore": 2,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/kaapo-kakko-with-a-goal-vs-edmonton-oilers-6370411144112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/kaapo-kakko-with-a-goal-vs-les-oilers-d-edmonton-6370411828112",
+                "highlightClip": 6370411144112,
+                "highlightClipFr": 6370411828112,
+                "discreteClip": 6370411830112,
+                "discreteClipFr": 6370411047112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev626.json"
+        },
+        {
+            "eventId": 67,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:01",
+            "timeRemaining": "12:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 358,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 640,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:06",
+            "timeRemaining": "12:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": 2,
+                "yCoord": 24,
+                "zoneCode": "N",
+                "playerId": 8476454,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 651,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:14",
+            "timeRemaining": "12:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 360,
+            "details": {
+                "xCoord": -2,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "playerId": 8483497,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:28",
+            "timeRemaining": "12:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 361,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 68,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:28",
+            "timeRemaining": "12:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 363,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:42",
+            "timeRemaining": "12:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 364,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 69,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:42",
+            "timeRemaining": "12:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 366,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 636,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:00",
+            "timeRemaining": "12:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 368,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 13,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 369,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 372,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477401,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 641,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:35",
+            "timeRemaining": "11:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 373,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 642,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:38",
+            "timeRemaining": "11:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 374,
+            "details": {
+                "xCoord": 81,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8479372,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 643,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:39",
+            "timeRemaining": "11:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 376,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 378,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477015,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 671,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:57",
+            "timeRemaining": "10:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 390,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8480803
+            }
+        },
+        {
+            "eventId": 665,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:17",
+            "timeRemaining": "09:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 396,
+            "details": {
+                "xCoord": 49,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 26,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 397,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 400,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 669,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:29",
+            "timeRemaining": "09:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 682,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:37",
+            "timeRemaining": "09:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 402,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -9,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8475786,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 691,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:49",
+            "timeRemaining": "09:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 403,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482665,
+                "hitteePlayerId": 8474641
+            }
+        },
+        {
+            "eventId": 681,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:14",
+            "timeRemaining": "08:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 414,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8476967,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 698,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:29",
+            "timeRemaining": "08:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 415,
+            "details": {
+                "xCoord": -36,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479372
+            }
+        },
+        {
+            "eventId": 697,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:19",
+            "timeRemaining": "07:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 424,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8476454
+            }
+        },
+        {
+            "eventId": 693,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:31",
+            "timeRemaining": "07:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 426,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8475784,
+                "scoringPlayerTotal": 14,
+                "assist1PlayerId": 8477015,
+                "assist1PlayerTotal": 17,
+                "assist2PlayerId": 8475218,
+                "assist2PlayerTotal": 23,
+                "eventOwnerTeamId": 22,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-skinner-scores-goal-against-joey-daccord-6370412817112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-skinner-marque-un-but-contre-joey-daccord-6370411535112",
+                "highlightClip": 6370412817112,
+                "highlightClipFr": 6370411535112,
+                "discreteClip": 6370412711112,
+                "discreteClipFr": 6370412413112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev693.json"
+        },
+        {
+            "eventId": 307,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:31",
+            "timeRemaining": "07:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 429,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477955,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 755,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:39",
+            "timeRemaining": "07:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 430,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8478013
+            }
+        },
+        {
+            "eventId": 751,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:48",
+            "timeRemaining": "07:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 431,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8480009,
+                "drawnByPlayerId": 8477498,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 72,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:48",
+            "timeRemaining": "07:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 435,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:59",
+            "timeRemaining": "06:01",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 438,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8476454,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:28",
+            "timeRemaining": "05:32",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 444,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 73,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:28",
+            "timeRemaining": "05:32",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 446,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 767,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:33",
+            "timeRemaining": "05:27",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 447,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 771,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:54",
+            "timeRemaining": "05:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 450,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 16,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:55",
+            "timeRemaining": "05:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 452,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:55",
+            "timeRemaining": "05:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 455,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:57",
+            "timeRemaining": "05:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 456,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 16,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 779,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 457,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 781,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:26",
+            "timeRemaining": "04:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 458,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking-double-minor",
+                "duration": 4,
+                "committedByPlayerId": 8478407,
+                "drawnByPlayerId": 8475786,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 75,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:26",
+            "timeRemaining": "04:34",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 462,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475784,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 784,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:35",
+            "timeRemaining": "04:25",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 463,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 16,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 787,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:38",
+            "timeRemaining": "04:22",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 464,
+            "details": {
+                "xCoord": -64,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8475786
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 467,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8478042
+            }
+        },
+        {
+            "eventId": 788,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:19",
+            "timeRemaining": "03:41",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 468,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 16,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 799,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 472,
+            "details": {
+                "xCoord": -18,
+                "yCoord": -27,
+                "zoneCode": "N",
+                "playerId": 8482665,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 794,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:38",
+            "timeRemaining": "03:22",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 473,
+            "details": {
+                "xCoord": -42,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:02",
+            "timeRemaining": "02:58",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 477,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8470621,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 807,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:05",
+            "timeRemaining": "02:55",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 478,
+            "details": {
+                "xCoord": -90,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8478013
+            }
+        },
+        {
+            "eventId": 800,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:13",
+            "timeRemaining": "02:47",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 480,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 487,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8476454,
+                "scoringPlayerTotal": 19,
+                "assist1PlayerId": 8475786,
+                "assist1PlayerTotal": 17,
+                "assist2PlayerId": 8480803,
+                "assist2PlayerTotal": 42,
+                "eventOwnerTeamId": 22,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-nugent-hopkins-scores-ppg-against-joey-daccord-6370410870112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-nugent-hopkins-marque-un-but-en-a-n-contre-joey-daccord-6370411165112",
+                "highlightClip": 6370410870112,
+                "highlightClipFr": 6370411165112,
+                "discreteClip": 6370411069112,
+                "discreteClipFr": 6370411850112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev810.json"
+        },
+        {
+            "eventId": 76,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 491,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8478585,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:22",
+            "timeRemaining": "01:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 492,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 77,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:22",
+            "timeRemaining": "01:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 493,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478585,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 821,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:40",
+            "timeRemaining": "01:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 494,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 15,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 822,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:50",
+            "timeRemaining": "01:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 816,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:52",
+            "timeRemaining": "01:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 496,
+            "details": {
+                "xCoord": -52,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478585,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 18,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:54",
+            "timeRemaining": "01:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 497,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:54",
+            "timeRemaining": "01:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 500,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 831,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:57",
+            "timeRemaining": "01:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 501,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 827,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:09",
+            "timeRemaining": "00:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 502,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:30",
+            "timeRemaining": "00:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 503,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8481617
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 506,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 509,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 828,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:49",
+            "timeRemaining": "00:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 510,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480803,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:53",
+            "timeRemaining": "00:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 511,
+            "details": {
+                "xCoord": 86,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8480803
+            }
+        },
+        {
+            "eventId": 829,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:55",
+            "timeRemaining": "00:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 512,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:59",
+            "timeRemaining": "00:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 513,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 208,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:59",
+            "timeRemaining": "00:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 514,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 515
+        },
+        {
+            "eventId": 902,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 521
+        },
+        {
+            "eventId": 901,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 523,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475784,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 845,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:09",
+            "timeRemaining": "19:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 524,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "playerId": 8474586,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 837,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:17",
+            "timeRemaining": "19:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 525,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 19,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 526,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 19,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 853,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 533,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:24",
+            "timeRemaining": "18:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 534,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8480803,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 847,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 535,
+            "details": {
+                "xCoord": 58,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 19,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 859,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:04",
+            "timeRemaining": "17:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 541,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8470621
+            }
+        },
+        {
+            "eventId": 862,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:16",
+            "timeRemaining": "17:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 544,
+            "details": {
+                "xCoord": -21,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "playerId": 8475786
+            }
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:59",
+            "timeRemaining": "17:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:05",
+            "timeRemaining": "16:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 551,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 506,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:06",
+            "timeRemaining": "16:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 552,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 21,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 507,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:07",
+            "timeRemaining": "16:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "poke",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 22,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 554,
+            "details": {
+                "reason": "chlg-hm-goal-interference",
+                "secondaryReason": "chlg-hm-goal-interference"
+            }
+        },
+        {
+            "eventId": 903,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 558,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477406,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 863,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:20",
+            "timeRemaining": "16:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "snap",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 870,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:50",
+            "timeRemaining": "16:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 560,
+            "details": {
+                "xCoord": 11,
+                "yCoord": 10,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 568,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 570,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 869,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:16",
+            "timeRemaining": "15:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:18",
+            "timeRemaining": "15:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 572,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 905,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:18",
+            "timeRemaining": "15:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 575,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 873,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:19",
+            "timeRemaining": "15:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 576,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481554,
+                "shootingPlayerId": 8478042,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 877,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:28",
+            "timeRemaining": "15:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 577,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 33,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 874,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:48",
+            "timeRemaining": "15:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 578,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 884,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 579,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8476454
+            }
+        },
+        {
+            "eventId": 886,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:21",
+            "timeRemaining": "14:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 587,
+            "details": {
+                "xCoord": 55,
+                "yCoord": 28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 893,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:30",
+            "timeRemaining": "14:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 588,
+            "details": {
+                "xCoord": 21,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 880,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:38",
+            "timeRemaining": "14:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 589,
+            "details": {
+                "xCoord": -33,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 881,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:49",
+            "timeRemaining": "14:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 590,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 24,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 882,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:57",
+            "timeRemaining": "14:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 591,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8477444,
+                "scoringPlayerTotal": 7,
+                "assist1PlayerId": 8477955,
+                "assist1PlayerTotal": 30,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479973,
+                "awayScore": 3,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-burakovsky-scores-goal-against-stuart-skinner-6370411674112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-burakovsky-marque-un-but-contre-stuart-skinner-6370412057112",
+                "highlightClip": 6370411674112,
+                "highlightClipFr": 6370412057112,
+                "discreteClip": 6370412757112,
+                "discreteClipFr": 6370413037112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev882.json"
+        },
+        {
+            "eventId": 210,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:57",
+            "timeRemaining": "14:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 594,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 211,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:01",
+            "timeRemaining": "13:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 595,
+            "details": {
+                "xCoord": -2,
+                "yCoord": 0,
+                "zoneCode": "N",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 24,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 212,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:26",
+            "timeRemaining": "13:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": 33,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:52",
+            "timeRemaining": "13:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 602,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 906,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:52",
+            "timeRemaining": "13:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 604,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:07",
+            "timeRemaining": "12:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 605,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 213,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:07",
+            "timeRemaining": "12:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 606,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:12",
+            "timeRemaining": "12:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 607,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 908,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:12",
+            "timeRemaining": "12:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 609,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 909,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:18",
+            "timeRemaining": "12:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 610,
+            "details": {
+                "xCoord": -30,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:03",
+            "timeRemaining": "11:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 614,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8475786
+            }
+        },
+        {
+            "eventId": 951,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:27",
+            "timeRemaining": "11:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 618,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 25,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 957,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:32",
+            "timeRemaining": "11:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": -43,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 961,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:55",
+            "timeRemaining": "11:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 622,
+            "details": {
+                "xCoord": -89,
+                "yCoord": -23,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8478013
+            }
+        },
+        {
+            "eventId": 953,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:06",
+            "timeRemaining": "10:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 623,
+            "details": {
+                "xCoord": -62,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477406,
+                "shootingPlayerId": 8483497,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 626,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 910,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 629,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8478585,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 214,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:52",
+            "timeRemaining": "10:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 630,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 970,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 632,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477955,
+                "hitteePlayerId": 8476967
+            }
+        },
+        {
+            "eventId": 978,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 633,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8481617
+            }
+        },
+        {
+            "eventId": 964,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8475786,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 965,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:28",
+            "timeRemaining": "09:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 637,
+            "details": {
+                "xCoord": 30,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 25,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 979,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:34",
+            "timeRemaining": "09:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 639,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 12,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 969,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 645,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480803,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 652,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479591,
+                "shootingPlayerId": 8474641,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 976,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:55",
+            "timeRemaining": "08:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 655,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8477498,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:57",
+            "timeRemaining": "08:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 656,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 911,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:57",
+            "timeRemaining": "08:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 658,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 981,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:59",
+            "timeRemaining": "08:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 659,
+            "details": {
+                "xCoord": 41,
+                "yCoord": 25,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481554,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:53",
+            "timeRemaining": "07:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 661,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 912,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:53",
+            "timeRemaining": "07:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 664,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476454,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 665,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 913,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 666,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 986,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:20",
+            "timeRemaining": "06:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 667,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 25,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:22",
+            "timeRemaining": "06:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 668,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 914,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:22",
+            "timeRemaining": "06:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 671,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8478585,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 989,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 672,
+            "details": {
+                "xCoord": 50,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8476967,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1001,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:52",
+            "timeRemaining": "06:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 673,
+            "details": {
+                "xCoord": -93,
+                "yCoord": -24,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8478585,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 995,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:05",
+            "timeRemaining": "05:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 676,
+            "details": {
+                "xCoord": -22,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 996,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:59",
+            "timeRemaining": "05:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 683,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 26,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 997,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:08",
+            "timeRemaining": "04:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 685,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 26,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 998,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:18",
+            "timeRemaining": "04:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 688,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:24",
+            "timeRemaining": "04:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 689,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 915,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:24",
+            "timeRemaining": "04:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 692,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477955,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1005,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:39",
+            "timeRemaining": "04:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 693,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -30,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8475786
+            }
+        },
+        {
+            "eventId": 1002,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:46",
+            "timeRemaining": "04:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 694,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8477498,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 216,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:47",
+            "timeRemaining": "04:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 695,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 26,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 551,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 696,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 916,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 699,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1006,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:15",
+            "timeRemaining": "03:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 700,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 26,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 1011,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:22",
+            "timeRemaining": "03:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 701,
+            "details": {
+                "xCoord": -45,
+                "yCoord": 32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477498
+            }
+        },
+        {
+            "eventId": 552,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8481617,
+                "drawnByPlayerId": 8476467,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 917,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 708,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1014,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:43",
+            "timeRemaining": "02:17",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 712,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "scoringPlayerId": 8476454,
+                "scoringPlayerTotal": 20,
+                "assist1PlayerId": 8478013,
+                "assist1PlayerTotal": 30,
+                "eventOwnerTeamId": 22,
+                "awayScore": 3,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-nugent-hopkins-scores-empty-net-goal-6370412461112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-nugent-hopkins-edm-marque-un-but-dans-un-filet-desert-6370413345112",
+                "highlightClip": 6370412461112,
+                "highlightClipFr": 6370413345112,
+                "discreteClip": 6370412657112,
+                "discreteClipFr": 6370414424112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev1014.json"
+        },
+        {
+            "eventId": 556,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:43",
+            "timeRemaining": "02:17",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 713,
+            "details": {
+                "reason": "objects-on-ice"
+            }
+        },
+        {
+            "eventId": 918,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:43",
+            "timeRemaining": "02:17",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 716,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477406,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1018,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 718,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 20,
+                "assist1PlayerId": 8477955,
+                "assist1PlayerTotal": 31,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 22,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479973,
+                "awayScore": 4,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-edm-schwartz-scores-ppg-against-stuart-skinner-6370412769112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-edm-schwartz-marque-un-but-contre-stuart-skinner-6370414719112",
+                "highlightClip": 6370412769112,
+                "highlightClipFr": 6370414719112,
+                "discreteClip": 6370413347112,
+                "discreteClipFr": 6370412875112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021116/ev1018.json"
+        },
+        {
+            "eventId": 217,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 722,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1022,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:09",
+            "timeRemaining": "01:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 723,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 1024,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 724,
+            "details": {
+                "xCoord": 19,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "playerId": 8478042
+            }
+        },
+        {
+            "eventId": 557,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:38",
+            "timeRemaining": "01:22",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 726,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 919,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:38",
+            "timeRemaining": "01:22",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 727,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 558,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:04",
+            "timeRemaining": "00:56",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 730,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 559,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:04",
+            "timeRemaining": "00:56",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 731,
+            "details": {
+                "reason": "visitor-timeout",
+                "secondaryReason": "visitor-timeout"
+            }
+        },
+        {
+            "eventId": 920,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:04",
+            "timeRemaining": "00:56",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 732,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1029,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:14",
+            "timeRemaining": "00:46",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 733,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -35,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8477955,
+                "drawnByPlayerId": 8475218,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 921,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:14",
+            "timeRemaining": "00:46",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 737,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1034,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:23",
+            "timeRemaining": "00:37",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 738,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478916
+            }
+        },
+        {
+            "eventId": 1037,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:29",
+            "timeRemaining": "00:31",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 739,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "playerId": 8478407,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 508,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:46",
+            "timeRemaining": "00:14",
+            "situationCode": "0551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 741,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8478042,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1033,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:55",
+            "timeRemaining": "00:05",
+            "situationCode": "0551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 742,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475786,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1035,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:59",
+            "timeRemaining": "00:01",
+            "situationCode": "0551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 743,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479973,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 560,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 744
+        },
+        {
+            "eventId": 564,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 748
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 22,
+            "playerId": 8470621,
+            "firstName": {
+                "default": "Corey"
+            },
+            "lastName": {
+                "default": "Perry"
+            },
+            "sweaterNumber": 90,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8470621.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8474641,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Henrique"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8474641.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475218,
+            "firstName": {
+                "default": "Mattias"
+            },
+            "lastName": {
+                "default": "Ekholm"
+            },
+            "sweaterNumber": 14,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475218.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475717,
+            "firstName": {
+                "default": "Calvin"
+            },
+            "lastName": {
+                "default": "Pickard"
+            },
+            "sweaterNumber": 30,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475717.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475784,
+            "firstName": {
+                "default": "Jeff"
+            },
+            "lastName": {
+                "default": "Skinner"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475784.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475786,
+            "firstName": {
+                "default": "Zach"
+            },
+            "lastName": {
+                "default": "Hyman"
+            },
+            "sweaterNumber": 18,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475786.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8476454,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Nugent-Hopkins"
+            },
+            "sweaterNumber": 93,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8476454.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8476967,
+            "firstName": {
+                "default": "Brett"
+            },
+            "lastName": {
+                "default": "Kulak"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8476967.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477015,
+            "firstName": {
+                "default": "Connor"
+            },
+            "lastName": {
+                "default": "Brown"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477015.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477406,
+            "firstName": {
+                "default": "Mattias"
+            },
+            "lastName": {
+                "default": "Janmark"
+            },
+            "sweaterNumber": 13,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477406.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477498,
+            "firstName": {
+                "default": "Darnell"
+            },
+            "lastName": {
+                "default": "Nurse"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477498.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477953,
+            "firstName": {
+                "default": "Kasperi"
+            },
+            "lastName": {
+                "default": "Kapanen"
+            },
+            "sweaterNumber": 42,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477953.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8478013,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "Walman"
+            },
+            "sweaterNumber": 96,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8478013.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8478042,
+            "firstName": {
+                "default": "Viktor"
+            },
+            "lastName": {
+                "default": "Arvidsson"
+            },
+            "sweaterNumber": 33,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8478042.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8478585,
+            "firstName": {
+                "default": "Derek"
+            },
+            "lastName": {
+                "default": "Ryan"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8478585.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8479368,
+            "firstName": {
+                "default": "Max"
+            },
+            "lastName": {
+                "default": "Jones"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8479368.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479372,
+            "firstName": {
+                "default": "Joshua",
+                "cs": "Josh",
+                "de": "Josh",
+                "es": "Josh",
+                "fi": "Josh",
+                "sk": "Josh",
+                "sv": "Josh"
+            },
+            "lastName": {
+                "default": "Mahura"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479372.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8479442,
+            "firstName": {
+                "default": "Troy"
+            },
+            "lastName": {
+                "default": "Stecher"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8479442.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8479973,
+            "firstName": {
+                "default": "Stuart"
+            },
+            "lastName": {
+                "default": "Skinner"
+            },
+            "sweaterNumber": 74,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8479973.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8480803,
+            "firstName": {
+                "default": "Evan"
+            },
+            "lastName": {
+                "default": "Bouchard"
+            },
+            "sweaterNumber": 2,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8480803.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8481617,
+            "firstName": {
+                "default": "Vasily",
+                "cs": "Vasilij",
+                "fi": "Vasili",
+                "sk": "Vasilij"
+            },
+            "lastName": {
+                "default": "Podkolzin"
+            },
+            "sweaterNumber": 92,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8481617.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -88,3 +88,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #68: Winnipeg Jets vs Seattle Kraken - Seattle loses 3-2 in OT](./2024-25/regular-season/20250316-WPG-vs-SEA-2024021072.json)
 - [GAME #69: Seattle Kraken vs Chicago Blackhawks - Seattle wins 6-2](./2024-25/regular-season/20250318-SEA-vs-CHI-2024021084.json)
 - [GAME #70: Seattle Kraken vs Minnesota Wild - Seattle loses 4-0](./2024-25/regular-season/20250319-SEA-vs-MIN-2024021088.json)
+- [GAME #71: Seattle Kraken vs Edmonton Oilers - Seattle loses 5-4](./2024-25/regular-season/20250322-SEA-vs-EDM-2024021116.json)


### PR DESCRIPTION
# Description

This PR adds the JSON data file for the Seattle Kraken's Game #71 against Edmonton Oilers on March 22, 2025. Seattle lost 5-4 to Edmonton. The PR includes:
- Game data JSON file
- Updated README.md with the game result

## Type of Change

version: chore    # General maintenance

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [ ] My commits are signed with GPG