### PR TITLE
chore: Add Kraken vs Flames game data from March 25, 2025

### DIFF
--- a/data/NHL - National Hockey League/2024-25/regular-season/20250325-SEA-vs-CGY-2024021137.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250325-SEA-vs-CGY-2024021137.json
@@ -1,0 +1,8750 @@
+{
+    "id": 2024021137,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-03-25",
+    "venue": {
+        "default": "Scotiabank Saddledome"
+    },
+    "venueLocation": {
+        "default": "Calgary"
+    },
+    "startTimeUTC": "2025-03-26T01:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-06:00",
+    "tvBroadcasts": [
+        {
+            "id": 289,
+            "market": "H",
+            "countryCode": "CA",
+            "network": "SNW",
+            "sequenceNumber": 34
+        },
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 4,
+        "periodType": "OT",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 3,
+        "sog": 29,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 20,
+        "commonName": {
+            "default": "Flames"
+        },
+        "abbrev": "CGY",
+        "score": 4,
+        "sog": 37,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/CGY_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/CGY_dark.svg",
+        "placeName": {
+            "default": "Calgary"
+        },
+        "placeNameWithPreposition": {
+            "default": "Calgary",
+            "fr": "de Calgary"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "01:02",
+        "secondsRemaining": 62,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "OT",
+        "otPeriods": 1
+    },
+    "plays": [
+        {
+            "eventId": 52,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 51,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8477955,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 103,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -36,
+                "yCoord": 23,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8477346,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 127,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:38",
+            "timeRemaining": "19:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 14,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8481028,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 149,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:05",
+            "timeRemaining": "17:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 36,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:13",
+            "timeRemaining": "17:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 39,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 143,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:27",
+            "timeRemaining": "17:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 41,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477401
+            }
+        },
+        {
+            "eventId": 140,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:52",
+            "timeRemaining": "17:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 51,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482624,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:54",
+            "timeRemaining": "17:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 52,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:54",
+            "timeRemaining": "17:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 55,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8481028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:57",
+            "timeRemaining": "17:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 56,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8477346,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 251,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:00",
+            "timeRemaining": "17:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 57,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477444,
+                "shootingPlayerId": 8477810,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:02",
+            "timeRemaining": "16:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 58,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 202,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:02",
+            "timeRemaining": "16:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 60,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475172,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:32",
+            "timeRemaining": "16:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 63,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475172,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:34",
+            "timeRemaining": "16:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 64,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:34",
+            "timeRemaining": "16:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 67,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:59",
+            "timeRemaining": "16:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 69,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 195,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:14",
+            "timeRemaining": "15:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 17,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480797,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482665,
+                "hitteePlayerId": 8480797
+            }
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:47",
+            "timeRemaining": "15:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 77,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8480797
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:54",
+            "timeRemaining": "15:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 78,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8481068,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 167,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:56",
+            "timeRemaining": "15:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 79,
+            "details": {
+                "xCoord": 3,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 174,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:14",
+            "timeRemaining": "14:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 87,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "snap",
+                "shootingPlayerId": 8479066,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 186,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:19",
+            "timeRemaining": "14:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 88,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "playerId": 8482858,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 314,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:30",
+            "timeRemaining": "14:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 89,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8478397
+            }
+        },
+        {
+            "eventId": 331,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:54",
+            "timeRemaining": "14:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 98,
+            "details": {
+                "xCoord": 95,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8475768,
+                "hitteePlayerId": 8482624
+            }
+        },
+        {
+            "eventId": 184,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 99,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 196,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 109,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8480860,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 197,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:58",
+            "timeRemaining": "13:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 110,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8478397,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 198,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:08",
+            "timeRemaining": "12:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 111,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478397,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 307,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:42",
+            "timeRemaining": "12:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 119,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480797,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 2,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:45",
+            "timeRemaining": "12:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 120,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 55,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:45",
+            "timeRemaining": "12:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 123,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:49",
+            "timeRemaining": "12:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 124,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:49",
+            "timeRemaining": "12:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 125,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480797,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 324,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:54",
+            "timeRemaining": "12:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 126,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -33,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 315,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:10",
+            "timeRemaining": "11:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 128,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8476399,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 336,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:42",
+            "timeRemaining": "11:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 136,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482679
+            }
+        },
+        {
+            "eventId": 325,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:58",
+            "timeRemaining": "11:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 137,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 326,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:07",
+            "timeRemaining": "10:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 138,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477346,
+                "shootingPlayerId": 8481789,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 327,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:11",
+            "timeRemaining": "10:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 139,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480797,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 343,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 147,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -27,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 148,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 338,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:42",
+            "timeRemaining": "10:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 149,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:57",
+            "timeRemaining": "10:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 151,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 56,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:57",
+            "timeRemaining": "10:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 154,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475172,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 383,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:06",
+            "timeRemaining": "09:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 158,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 24,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8482074
+            }
+        },
+        {
+            "eventId": 384,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 160,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477346,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 360,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:37",
+            "timeRemaining": "09:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 164,
+            "details": {
+                "xCoord": 34,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482624
+            }
+        },
+        {
+            "eventId": 206,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:54",
+            "timeRemaining": "09:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483609,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 2,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 57,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:54",
+            "timeRemaining": "09:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 172,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8479291,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 357,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 173,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8483609,
+                "scoringPlayerTotal": 2,
+                "assist1PlayerId": 8479291,
+                "assist1PlayerTotal": 4,
+                "assist2PlayerId": 8482624,
+                "assist2PlayerTotal": 7,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8478916,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-klapka-scores-goal-against-joey-daccord-6370561571112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-klapka-marque-un-but-contre-joey-daccord-6370561296112",
+                "highlightClip": 6370561571112,
+                "highlightClipFr": 6370561296112,
+                "discreteClip": 6370561875112,
+                "discreteClipFr": 6370560593112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev357.json"
+        },
+        {
+            "eventId": 205,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 175,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8479291,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 361,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:05",
+            "timeRemaining": "08:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 176,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8479291,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 2,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 419,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:50",
+            "timeRemaining": "08:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 185,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 11,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480860,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 371,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:58",
+            "timeRemaining": "08:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 186,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478397,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:31",
+            "timeRemaining": "07:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 195,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:31",
+            "timeRemaining": "07:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 198,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8477955,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 433,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:37",
+            "timeRemaining": "07:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 199,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477810,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 386,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:02",
+            "timeRemaining": "06:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 393,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:20",
+            "timeRemaining": "06:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 208,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 4,
+                "zoneCode": "N",
+                "shotType": "slap",
+                "shootingPlayerId": 8476399,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 3,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 439,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:28",
+            "timeRemaining": "06:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 209,
+            "details": {
+                "xCoord": 33,
+                "yCoord": -23,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8479402,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 394,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:33",
+            "timeRemaining": "06:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 210,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 395,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:39",
+            "timeRemaining": "06:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 211,
+            "details": {
+                "xCoord": 51,
+                "yCoord": 21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 396,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:44",
+            "timeRemaining": "06:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 212,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:45",
+            "timeRemaining": "06:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 213,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:45",
+            "timeRemaining": "06:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 216,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8481554,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 451,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 217,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480860,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 459,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:05",
+            "timeRemaining": "05:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 218,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480860,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 401,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:13",
+            "timeRemaining": "05:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 220,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480028,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 5,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:19",
+            "timeRemaining": "05:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 221,
+            "details": {
+                "xCoord": -24,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 410,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:49",
+            "timeRemaining": "05:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 228,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478397,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 5,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:53",
+            "timeRemaining": "05:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 229,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 415,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:04",
+            "timeRemaining": "04:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 232,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -33,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8479291,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:06",
+            "timeRemaining": "04:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 233,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 60,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:06",
+            "timeRemaining": "04:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 236,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8481028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 430,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:19",
+            "timeRemaining": "04:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 237,
+            "details": {
+                "xCoord": 4,
+                "yCoord": 26,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8477346
+            }
+        },
+        {
+            "eventId": 487,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:33",
+            "timeRemaining": "04:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 239,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8475172
+            }
+        },
+        {
+            "eventId": 428,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:46",
+            "timeRemaining": "04:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 246,
+            "details": {
+                "xCoord": 8,
+                "yCoord": 26,
+                "zoneCode": "N",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 489,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:51",
+            "timeRemaining": "04:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 248,
+            "details": {
+                "xCoord": 37,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8481068
+            }
+        },
+        {
+            "eventId": 490,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:54",
+            "timeRemaining": "04:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 249,
+            "details": {
+                "xCoord": 44,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477810,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 429,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:56",
+            "timeRemaining": "04:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 250,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:58",
+            "timeRemaining": "04:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 251,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 61,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:58",
+            "timeRemaining": "04:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 253,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8480009,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 434,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:07",
+            "timeRemaining": "03:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 254,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481068,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:09",
+            "timeRemaining": "03:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 255,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 207,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:09",
+            "timeRemaining": "03:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 256,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8481068,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 440,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 257,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 437,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:33",
+            "timeRemaining": "03:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 258,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480797,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 443,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:44",
+            "timeRemaining": "03:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 261,
+            "details": {
+                "xCoord": 48,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:06",
+            "timeRemaining": "02:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 267,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:06",
+            "timeRemaining": "02:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 268,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8479291,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 449,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:09",
+            "timeRemaining": "02:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 269,
+            "details": {
+                "xCoord": 41,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483609,
+                "shootingPlayerId": 8479985,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:11",
+            "timeRemaining": "02:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 270,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:11",
+            "timeRemaining": "02:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 271,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8479291,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 452,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:15",
+            "timeRemaining": "02:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 272,
+            "details": {
+                "xCoord": 46,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479291,
+                "shootingPlayerId": 8479591,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 273,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 455,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 274,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "cross-checking",
+                "duration": 2,
+                "committedByPlayerId": 8479066,
+                "drawnByPlayerId": 8481789,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 278,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8479291,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 486,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:30",
+            "timeRemaining": "00:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 304,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 305
+        },
+        {
+            "eventId": 66,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 310
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 313,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8477955,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 495,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:47",
+            "timeRemaining": "19:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 316,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480860,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 8,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:53",
+            "timeRemaining": "18:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 325,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 208,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:53",
+            "timeRemaining": "18:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 328,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 559,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:59",
+            "timeRemaining": "18:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 329,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8479402
+            }
+        },
+        {
+            "eventId": 563,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:05",
+            "timeRemaining": "17:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 330,
+            "details": {
+                "xCoord": -90,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482665,
+                "hitteePlayerId": 8479402
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 331,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 209,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 332,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481068,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 210,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 334,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481068,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 574,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:33",
+            "timeRemaining": "17:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 335,
+            "details": {
+                "xCoord": 42,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8476399,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 575,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:38",
+            "timeRemaining": "17:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 336,
+            "details": {
+                "xCoord": 48,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 577,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:40",
+            "timeRemaining": "17:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 337,
+            "details": {
+                "xCoord": 27,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "playerId": 8477986,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 579,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:55",
+            "timeRemaining": "17:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 341,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 565,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:01",
+            "timeRemaining": "16:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 344,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483609,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 571,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:04",
+            "timeRemaining": "16:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 345,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8479066,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 67,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:04",
+            "timeRemaining": "16:56",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 349,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 576,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:34",
+            "timeRemaining": "16:26",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 8,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:35",
+            "timeRemaining": "16:25",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 351,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 68,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:35",
+            "timeRemaining": "16:25",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 352,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 589,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:39",
+            "timeRemaining": "16:21",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476467
+            }
+        },
+        {
+            "eventId": 580,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:42",
+            "timeRemaining": "16:18",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": 37,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477346,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 8,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 581,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:53",
+            "timeRemaining": "16:07",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 355,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475172,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 8,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 592,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:20",
+            "timeRemaining": "15:40",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 356,
+            "details": {
+                "xCoord": 18,
+                "yCoord": 35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482679
+            }
+        },
+        {
+            "eventId": 597,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:20",
+            "timeRemaining": "15:40",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 357,
+            "details": {
+                "xCoord": 12,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8482679
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:51",
+            "timeRemaining": "15:09",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 364,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8480797
+            }
+        },
+        {
+            "eventId": 590,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:03",
+            "timeRemaining": "14:57",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478397,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 8,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 593,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:09",
+            "timeRemaining": "14:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 367,
+            "details": {
+                "xCoord": -70,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:11",
+            "timeRemaining": "14:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 368,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 211,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:11",
+            "timeRemaining": "14:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 371,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475172,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 372,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 212,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 373,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8475768,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 600,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:17",
+            "timeRemaining": "14:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 374,
+            "details": {
+                "xCoord": -42,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 609,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:24",
+            "timeRemaining": "14:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 375,
+            "details": {
+                "xCoord": 11,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8481028
+            }
+        },
+        {
+            "eventId": 620,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:25",
+            "timeRemaining": "13:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 387,
+            "details": {
+                "xCoord": 43,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 621,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:34",
+            "timeRemaining": "13:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 388,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 32,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8479402
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:47",
+            "timeRemaining": "13:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 390,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 69,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:47",
+            "timeRemaining": "13:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 392,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 617,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:07",
+            "timeRemaining": "12:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 393,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479402,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 10,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:10",
+            "timeRemaining": "12:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 394,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:10",
+            "timeRemaining": "12:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 396,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:32",
+            "timeRemaining": "12:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 399,
+            "details": {
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 627,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:21",
+            "timeRemaining": "11:39",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 402,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 629,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:30",
+            "timeRemaining": "11:30",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 403,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 637,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:33",
+            "timeRemaining": "11:27",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 404,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480028,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 634,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:44",
+            "timeRemaining": "11:16",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 405,
+            "details": {
+                "xCoord": 14,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "typeCode": "BEN",
+                "descKey": "too-many-men-on-the-ice",
+                "duration": 2,
+                "servedByPlayerId": 8482074,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 213,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:44",
+            "timeRemaining": "11:16",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 409,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8479291,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:17",
+            "timeRemaining": "10:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 410,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:17",
+            "timeRemaining": "10:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 412,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8475768,
+                "winningPlayerId": 8480797,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 648,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 413,
+            "details": {
+                "xCoord": -93,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8481692
+            }
+        },
+        {
+            "eventId": 649,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 414,
+            "details": {
+                "xCoord": -30,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 214,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:32",
+            "timeRemaining": "10:28",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": 65,
+                "yCoord": -16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8480797,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 642,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:57",
+            "timeRemaining": "10:03",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 417,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477346,
+                "shootingPlayerId": 8477955,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 652,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:01",
+            "timeRemaining": "09:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 418,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8476399
+            }
+        },
+        {
+            "eventId": 643,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:03",
+            "timeRemaining": "09:57",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 419,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 644,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:17",
+            "timeRemaining": "09:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 420,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480797,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 421,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 21,
+                "assist1PlayerId": 8477955,
+                "assist1PlayerTotal": 32,
+                "assist2PlayerId": 8477444,
+                "assist2PlayerTotal": 21,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8481692,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-schwartz-scores-ppg-against-dustin-wolf-6370561627112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-schwartz-marque-un-but-en-a-n-contre-dustin-wolf-6370562339112",
+                "highlightClip": 6370561627112,
+                "highlightClipFr": 6370562339112,
+                "discreteClip": 6370562608112,
+                "discreteClipFr": 6370561449112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev646.json"
+        },
+        {
+            "eventId": 215,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 425,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8475172,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 654,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:38",
+            "timeRemaining": "09:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 426,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8481028,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:44",
+            "timeRemaining": "09:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 427,
+            "details": {
+                "xCoord": -26,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 659,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:12",
+            "timeRemaining": "08:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 431,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8480028,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 216,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:18",
+            "timeRemaining": "08:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 433,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 689,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:18",
+            "timeRemaining": "08:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 434,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8482074
+            }
+        },
+        {
+            "eventId": 662,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:29",
+            "timeRemaining": "08:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 437,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 674,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:39",
+            "timeRemaining": "08:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "playerId": 8476456,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 678,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:40",
+            "timeRemaining": "08:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8476456
+            }
+        },
+        {
+            "eventId": 671,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:00",
+            "timeRemaining": "08:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 446,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480028,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 12,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 694,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 450,
+            "details": {
+                "xCoord": -38,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8477346
+            }
+        },
+        {
+            "eventId": 700,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:19",
+            "timeRemaining": "07:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 453,
+            "details": {
+                "xCoord": 87,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 680,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:35",
+            "timeRemaining": "07:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 455,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:45",
+            "timeRemaining": "07:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 458,
+            "details": {
+                "xCoord": 90,
+                "yCoord": -32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8479066,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 464,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 75,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 467,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 692,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:15",
+            "timeRemaining": "06:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 468,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477810,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 12,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:18",
+            "timeRemaining": "06:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 469,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 76,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:18",
+            "timeRemaining": "06:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 470,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8481068,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:32",
+            "timeRemaining": "06:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 471,
+            "details": {
+                "xCoord": -4,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 482,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 77,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 483,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475172,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:17",
+            "timeRemaining": "05:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 484,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 12,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 761,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:31",
+            "timeRemaining": "05:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 485,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 762,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:35",
+            "timeRemaining": "05:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 486,
+            "details": {
+                "xCoord": -47,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 487,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 78,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 490,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 766,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:42",
+            "timeRemaining": "05:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 491,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 492,
+            "details": {
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 769,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:49",
+            "timeRemaining": "05:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 493,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 25,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8477810,
+                "drawnByPlayerId": 8481554,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 79,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:49",
+            "timeRemaining": "05:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 497,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8475768,
+                "winningPlayerId": 8479291,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 500,
+            "details": {
+                "xCoord": -30,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 782,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 507,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 795,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:08",
+            "timeRemaining": "03:52",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 508,
+            "details": {
+                "xCoord": -39,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8479291,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 785,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:23",
+            "timeRemaining": "03:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 510,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "slap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 786,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 511,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 790,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:57",
+            "timeRemaining": "03:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 515,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 791,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:07",
+            "timeRemaining": "02:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 516,
+            "details": {
+                "xCoord": -44,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:10",
+            "timeRemaining": "02:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 517,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 218,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:10",
+            "timeRemaining": "02:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 520,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8479591,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 813,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:14",
+            "timeRemaining": "02:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 521,
+            "details": {
+                "xCoord": -91,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8477346
+            }
+        },
+        {
+            "eventId": 804,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:19",
+            "timeRemaining": "02:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 522,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "playerId": 8479591,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 796,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:24",
+            "timeRemaining": "02:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 523,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 816,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 524,
+            "details": {
+                "xCoord": -55,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8475172,
+                "hitteePlayerId": 8477401
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:36",
+            "timeRemaining": "02:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 525,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8477810,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 811,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:40",
+            "timeRemaining": "02:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 527,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477401
+            }
+        },
+        {
+            "eventId": 800,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:53",
+            "timeRemaining": "02:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 529,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8482074,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 832,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 530,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8482074
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:42",
+            "timeRemaining": "01:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 539,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8481789,
+                "scoringPlayerTotal": 5,
+                "assist1PlayerId": 8478407,
+                "assist1PlayerTotal": 23,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8481692,
+                "awayScore": 2,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-kartye-scores-goal-against-dustin-wolf-6370561856112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-kartye-marque-un-but-contre-dustin-wolf-6370561860112",
+                "highlightClip": 6370561856112,
+                "highlightClipFr": 6370561860112,
+                "discreteClip": 6370562531112,
+                "discreteClipFr": 6370562163112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev810.json"
+        },
+        {
+            "eventId": 219,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:42",
+            "timeRemaining": "01:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 542,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8481068,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:55",
+            "timeRemaining": "01:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 543,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477346,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 18,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 818,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:06",
+            "timeRemaining": "00:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 544,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 821,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:18",
+            "timeRemaining": "00:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": 42,
+                "yCoord": 30,
+                "zoneCode": "D",
+                "blockingPlayerId": 8474586,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:22",
+            "timeRemaining": "00:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": 11,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477444,
+                "hitteePlayerId": 8478397
+            }
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:29",
+            "timeRemaining": "00:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 554,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -16,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8474586,
+                "hitteePlayerId": 8480860
+            }
+        },
+        {
+            "eventId": 835,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:54",
+            "timeRemaining": "00:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8479402
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 560
+        },
+        {
+            "eventId": 81,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 565
+        },
+        {
+            "eventId": 80,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 568,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475172,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 844,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:03",
+            "timeRemaining": "19:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 569,
+            "details": {
+                "xCoord": 17,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8477346
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:15",
+            "timeRemaining": "19:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 570,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 19,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 959,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:16",
+            "timeRemaining": "19:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": 67,
+                "yCoord": 28,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477346,
+                "hitteePlayerId": 8480009
+            }
+        },
+        {
+            "eventId": 849,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:44",
+            "timeRemaining": "19:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 577,
+            "details": {
+                "xCoord": -88,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476457
+            }
+        },
+        {
+            "eventId": 845,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:44",
+            "timeRemaining": "19:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 578,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481028,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:51",
+            "timeRemaining": "19:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 579,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 220,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:51",
+            "timeRemaining": "19:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 582,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8483524,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 853,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:25",
+            "timeRemaining": "18:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 586,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:28",
+            "timeRemaining": "18:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 587,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 221,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:28",
+            "timeRemaining": "18:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 590,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 859,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 592,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476399,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 871,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:50",
+            "timeRemaining": "18:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 593,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:50",
+            "timeRemaining": "18:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 594,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479402,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 862,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:00",
+            "timeRemaining": "18:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476399,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 864,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:15",
+            "timeRemaining": "17:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 599,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480797,
+                "shootingPlayerId": 8476399,
+                "eventOwnerTeamId": 20,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 866,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:20",
+            "timeRemaining": "17:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 600,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8478397,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 867,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:24",
+            "timeRemaining": "17:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 601,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478397,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 603,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 222,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 605,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:38",
+            "timeRemaining": "17:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 606,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 223,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:38",
+            "timeRemaining": "17:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 607,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 876,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:06",
+            "timeRemaining": "16:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 611,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8477346,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 612,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 224,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 615,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482679,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 893,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 616,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8482679
+            }
+        },
+        {
+            "eventId": 897,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:52",
+            "timeRemaining": "16:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 624,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 32,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8480028
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:55",
+            "timeRemaining": "16:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 625,
+            "details": {
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 887,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:57",
+            "timeRemaining": "16:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 626,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 894,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 629,
+            "details": {
+                "xCoord": 22,
+                "yCoord": -3,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8482679,
+                "drawnByPlayerId": 8479591,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 82,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 633,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8479291,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 958,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:04",
+            "timeRemaining": "14:56",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 636,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8480860
+            }
+        },
+        {
+            "eventId": 1004,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:52",
+            "timeRemaining": "14:08",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 645,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -22,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477346,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 960,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 646,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:04",
+            "timeRemaining": "13:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 649,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477810,
+                "shootingPlayerId": 8477444,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 972,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:34",
+            "timeRemaining": "13:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 658,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 1017,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:38",
+            "timeRemaining": "13:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 659,
+            "details": {
+                "xCoord": -7,
+                "yCoord": -34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8482074,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:46",
+            "timeRemaining": "13:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 662,
+            "details": {
+                "xCoord": -39,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8481028,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 978,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:59",
+            "timeRemaining": "13:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 1020,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:28",
+            "timeRemaining": "12:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 672,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 985,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:31",
+            "timeRemaining": "12:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 673,
+            "details": {
+                "xCoord": 40,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 988,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:40",
+            "timeRemaining": "12:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 676,
+            "details": {
+                "xCoord": -12,
+                "yCoord": -24,
+                "zoneCode": "N",
+                "shotType": "slap",
+                "shootingPlayerId": 8477810,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 20,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 1026,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:11",
+            "timeRemaining": "11:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 685,
+            "details": {
+                "xCoord": -36,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8483609
+            }
+        },
+        {
+            "eventId": 1032,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:23",
+            "timeRemaining": "11:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 688,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -16,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8482679,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 999,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:29",
+            "timeRemaining": "11:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480028,
+                "shootingPlayerId": 8474586,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1016,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:33",
+            "timeRemaining": "11:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 690,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 1006,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 697,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 21,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 503,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:04",
+            "timeRemaining": "10:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 699,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 225,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:04",
+            "timeRemaining": "10:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 701,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475172,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1011,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:09",
+            "timeRemaining": "10:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 702,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8481028,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1013,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:17",
+            "timeRemaining": "10:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 703,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1014,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:23",
+            "timeRemaining": "10:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480860,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 504,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 705,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 226,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 708,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 84,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 709,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8482679,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1021,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 710,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478397,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:44",
+            "timeRemaining": "10:16",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 712,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1023,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:04",
+            "timeRemaining": "09:56",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 713,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8475172,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1024,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 714,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1028,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 715,
+            "details": {
+                "xCoord": -74,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking-double-minor",
+                "duration": 4,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8482679,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 227,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 719,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1033,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:26",
+            "timeRemaining": "09:34",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 720,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8475172,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 506,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:05",
+            "timeRemaining": "08:55",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 723,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 228,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:05",
+            "timeRemaining": "08:55",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 724,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482679,
+                "winningPlayerId": 8482665,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1046,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:35",
+            "timeRemaining": "08:25",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 725,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 1037,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:36",
+            "timeRemaining": "08:24",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 726,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475172,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 1038,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 727,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8477346,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1039,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:49",
+            "timeRemaining": "08:11",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 728,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8475172,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1048,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:12",
+            "timeRemaining": "07:48",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 735,
+            "details": {
+                "xCoord": -32,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8478397
+            }
+        },
+        {
+            "eventId": 1054,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:27",
+            "timeRemaining": "07:33",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 736,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482074
+            }
+        },
+        {
+            "eventId": 1077,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:40",
+            "timeRemaining": "07:20",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 737,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8480797
+            }
+        },
+        {
+            "eventId": 1047,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:55",
+            "timeRemaining": "07:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 738,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8478397,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1057,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:42",
+            "timeRemaining": "06:18",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 745,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475172,
+                "scoringPlayerTotal": 27,
+                "assist1PlayerId": 8476456,
+                "assist1PlayerTotal": 29,
+                "assist2PlayerId": 8480028,
+                "assist2PlayerTotal": 19,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-kadri-scores-ppg-against-joey-daccord-6370564537112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-kadri-marque-un-but-en-a-n-contre-joey-daccord-6370564845112",
+                "highlightClip": 6370564537112,
+                "highlightClipFr": 6370564845112,
+                "discreteClip": 6370563942112,
+                "discreteClipFr": 6370565329112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev1057.json"
+        },
+        {
+            "eventId": 229,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:42",
+            "timeRemaining": "06:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 749,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 507,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:50",
+            "timeRemaining": "06:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 750,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 230,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:50",
+            "timeRemaining": "06:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 751,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8481068,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1065,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 752,
+            "details": {
+                "xCoord": -26,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480860,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:09",
+            "timeRemaining": "05:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 753,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1067,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:14",
+            "timeRemaining": "05:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 754,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480797,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 1079,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:22",
+            "timeRemaining": "05:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 756,
+            "details": {
+                "xCoord": 7,
+                "yCoord": -12,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 1096,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 764,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477346,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 1081,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:04",
+            "timeRemaining": "04:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 768,
+            "details": {
+                "xCoord": -15,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475172,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 508,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 771,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 1090,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 772,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8479591,
+                "drawnByPlayerId": 8481028,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1093,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 774,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "unsportsmanlike-conduct",
+                "duration": 2,
+                "committedByPlayerId": 8481028,
+                "drawnByPlayerId": 8479591,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 231,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 776,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8475172,
+                "drawnByPlayerId": 8477986,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1086,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 778,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8475172,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 234,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 780,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 235,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 783,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481068,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1099,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:44",
+            "timeRemaining": "04:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 786,
+            "details": {
+                "xCoord": -47,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 21,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 509,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:45",
+            "timeRemaining": "04:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 787,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 236,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:45",
+            "timeRemaining": "04:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 790,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482679,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1103,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 791,
+            "details": {
+                "xCoord": -41,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "scoringPlayerId": 8478397,
+                "scoringPlayerTotal": 10,
+                "assist1PlayerId": 8482679,
+                "assist1PlayerTotal": 18,
+                "assist2PlayerId": 8476456,
+                "assist2PlayerTotal": 30,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-andersson-scores-goal-against-joey-daccord-6370565820112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-andersson-marque-un-but-contre-joey-daccord-6370565627112",
+                "highlightClip": 6370565820112,
+                "highlightClipFr": 6370565627112,
+                "discreteClip": 6370564548112,
+                "discreteClipFr": 6370563579112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev1103.json"
+        },
+        {
+            "eventId": 237,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:49",
+            "timeRemaining": "04:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 792,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480028,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1140,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:27",
+            "timeRemaining": "03:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 797,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8479291
+            }
+        },
+        {
+            "eventId": 1110,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:32",
+            "timeRemaining": "03:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 798,
+            "details": {
+                "xCoord": -33,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477346,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1158,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:51",
+            "timeRemaining": "02:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 814,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480028,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 1127,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:56",
+            "timeRemaining": "02:04",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 816,
+            "details": {
+                "xCoord": 48,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482679,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 512,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:03",
+            "timeRemaining": "01:57",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 817,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 85,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:03",
+            "timeRemaining": "01:57",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 822,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1134,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:27",
+            "timeRemaining": "01:33",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 823,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 22,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 1135,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:27",
+            "timeRemaining": "01:33",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 824,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 1136,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:30",
+            "timeRemaining": "01:30",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 825,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8474586,
+                "scoringPlayerTotal": 9,
+                "assist1PlayerId": 8482665,
+                "assist1PlayerTotal": 23,
+                "assist2PlayerId": 8475768,
+                "assist2PlayerTotal": 22,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8481692,
+                "awayScore": 3,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-eberle-scores-goal-against-dustin-wolf-6370563965112",
+                "highlightClip": 6370563965112,
+                "discreteClip": 6370565920112,
+                "discreteClipFr": 6370563957112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev1136.json"
+        },
+        {
+            "eventId": 86,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:30",
+            "timeRemaining": "01:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 828,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8477955,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 513,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:46",
+            "timeRemaining": "01:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 829,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 238,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:46",
+            "timeRemaining": "01:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 831,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1174,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:01",
+            "timeRemaining": "00:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 835,
+            "details": {
+                "xCoord": 3,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8481068
+            }
+        },
+        {
+            "eventId": 1157,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:34",
+            "timeRemaining": "00:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 841,
+            "details": {
+                "xCoord": -40,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "playerId": 8476456,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1159,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:40",
+            "timeRemaining": "00:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 843,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482679
+            }
+        },
+        {
+            "eventId": 514,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 847
+        },
+        {
+            "eventId": 88,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 853
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 855,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1170,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:33",
+            "timeRemaining": "04:27",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 857,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8480028
+            }
+        },
+        {
+            "eventId": 1168,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:20",
+            "timeRemaining": "03:40",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 863,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 24,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 519,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "03:38",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 864,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 89,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "03:38",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 869,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475172,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1175,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:07",
+            "timeRemaining": "02:53",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 873,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8482074,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1177,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 874,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480028,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 24,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 520,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:14",
+            "timeRemaining": "02:46",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 875,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 90,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:14",
+            "timeRemaining": "02:46",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 878,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1180,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "02:31",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 879,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 24,
+                "homeSOG": 32
+            }
+        },
+        {
+            "eventId": 1181,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:37",
+            "timeRemaining": "02:23",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 880,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 25,
+                "homeSOG": 32
+            }
+        },
+        {
+            "eventId": 1194,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "02:13",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 881,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -20,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477346,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 1183,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:04",
+            "timeRemaining": "01:56",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 884,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478397,
+                "shootingPlayerId": 8483524,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 521,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:05",
+            "timeRemaining": "01:55",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 885,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 239,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:05",
+            "timeRemaining": "01:55",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 887,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475172,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 240,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:32",
+            "timeRemaining": "01:28",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 888,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475172,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 25,
+                "homeSOG": 33
+            }
+        },
+        {
+            "eventId": 1193,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "01:12",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 892,
+            "details": {
+                "xCoord": -93,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "playerId": 8474586,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1189,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:50",
+            "timeRemaining": "01:10",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 893,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 26,
+                "homeSOG": 33
+            }
+        },
+        {
+            "eventId": 241,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "01:02",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 894,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475172,
+                "scoringPlayerTotal": 28,
+                "assist1PlayerId": 8482679,
+                "assist1PlayerTotal": 19,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8478916,
+                "awayScore": 3,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-kadri-scores-goal-against-joey-daccord-6370564569112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-kadri-marque-un-but-contre-joey-daccord-6370566821112",
+                "highlightClip": 6370564569112,
+                "highlightClipFr": 6370566821112,
+                "discreteClip": 6370564871112,
+                "discreteClipFr": 6370564755112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021137/ev241.json"
+        },
+        {
+            "eventId": 522,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "01:02",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 896
+        },
+        {
+            "eventId": 526,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "01:02",
+            "situationCode": "0440",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 900
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8475172,
+            "firstName": {
+                "default": "Nazem"
+            },
+            "lastName": {
+                "default": "Kadri"
+            },
+            "sweaterNumber": 91,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8475172.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8476399,
+            "firstName": {
+                "default": "Blake"
+            },
+            "lastName": {
+                "default": "Coleman"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8476399.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8476456,
+            "firstName": {
+                "default": "Jonathan"
+            },
+            "lastName": {
+                "default": "Huberdeau"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8476456.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8477346,
+            "firstName": {
+                "default": "MacKenzie"
+            },
+            "lastName": {
+                "default": "Weegar"
+            },
+            "sweaterNumber": 52,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8477346.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8477810,
+            "firstName": {
+                "default": "Joel"
+            },
+            "lastName": {
+                "default": "Hanley"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8477810.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8478397,
+            "firstName": {
+                "default": "Rasmus"
+            },
+            "lastName": {
+                "default": "Andersson"
+            },
+            "sweaterNumber": 4,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8478397.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8478435,
+            "firstName": {
+                "default": "Dan"
+            },
+            "lastName": {
+                "default": "Vladar",
+                "cs": "Vlada\u0159",
+                "sk": "Vlada\u0159"
+            },
+            "sweaterNumber": 80,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8478435.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8479066,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Lomberg"
+            },
+            "sweaterNumber": 70,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8479066.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8479291,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Rooney"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8479291.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8479402,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "Bean"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8479402.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479985,
+            "firstName": {
+                "default": "Cale"
+            },
+            "lastName": {
+                "default": "Fleury"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479985.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8480028,
+            "firstName": {
+                "default": "Morgan"
+            },
+            "lastName": {
+                "default": "Frost"
+            },
+            "sweaterNumber": 16,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8480028.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8480797,
+            "firstName": {
+                "default": "Joel"
+            },
+            "lastName": {
+                "default": "Farabee"
+            },
+            "sweaterNumber": 86,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8480797.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8480860,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Bahl"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8480860.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481028,
+            "firstName": {
+                "default": "Martin"
+            },
+            "lastName": {
+                "default": "Pospisil",
+                "cs": "Posp\u00ed\u0161il",
+                "sk": "Posp\u00ed\u0161il"
+            },
+            "sweaterNumber": 76,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8481028.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481068,
+            "firstName": {
+                "default": "Yegor",
+                "cs": "Jegor",
+                "fi": "Jahor",
+                "sk": "Jegor"
+            },
+            "lastName": {
+                "default": "Sharangovich",
+                "cs": "\u0160arangovi\u010d",
+                "fi": "Sharanhovitsh",
+                "sk": "\u0160arangovi\u010d"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8481068.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481692,
+            "firstName": {
+                "default": "Dustin"
+            },
+            "lastName": {
+                "default": "Wolf"
+            },
+            "sweaterNumber": 32,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8481692.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482074,
+            "firstName": {
+                "default": "Connor"
+            },
+            "lastName": {
+                "default": "Zary"
+            },
+            "sweaterNumber": 47,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8482074.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482624,
+            "firstName": {
+                "default": "Daniil"
+            },
+            "lastName": {
+                "default": "Miromanov"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8482624.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482679,
+            "firstName": {
+                "default": "Matt"
+            },
+            "lastName": {
+                "default": "Coronato"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8482679.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8483609,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Klapka"
+            },
+            "sweaterNumber": 43,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/CGY/8483609.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -89,3 +89,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #69: Seattle Kraken vs Chicago Blackhawks - Seattle wins 6-2](./2024-25/regular-season/20250318-SEA-vs-CHI-2024021084.json)
 - [GAME #70: Seattle Kraken vs Minnesota Wild - Seattle loses 4-0](./2024-25/regular-season/20250319-SEA-vs-MIN-2024021088.json)
 - [GAME #71: Seattle Kraken vs Edmonton Oilers - Seattle loses 5-4](./2024-25/regular-season/20250322-SEA-vs-EDM-2024021116.json)
+- [GAME #72: Seattle Kraken vs Calgary Flames - Seattle loses 4-3 in OT](./2024-25/regular-season/20250325-SEA-vs-CGY-2024021137.json)


### PR DESCRIPTION
# Description

Added the JSON data from the Seattle Kraken vs Calgary Flames game played on March 25, 2025. The Kraken lost 4-3 in overtime.

- Downloaded game data using the download:kraken script
- Updated the NHL README.md to include Game 72

## Type of Change

version: chore     # General maintenance

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] My commits are signed with GPG