### PR TITLE
chore: Add Oilers vs Kraken game data from March 27, 2025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1011,6 +1011,7 @@
     "Kleven",
     "Kliff",
     "Klimovich",
+    "Klingberg",
     "Klingele",
     "Kmec",
     "Knies",

--- a/data/NHL - National Hockey League/2024-25/regular-season/20250327-EDM-vs-SEA-2024021151.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250327-EDM-vs-SEA-2024021151.json
@@ -1,0 +1,8958 @@
+{
+    "id": 2024021151,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-03-27",
+    "venue": {
+        "default": "Climate Pledge Arena"
+    },
+    "venueLocation": {
+        "default": "Seattle"
+    },
+    "startTimeUTC": "2025-03-28T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 282,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "SN",
+            "sequenceNumber": 21
+        },
+        {
+            "id": 284,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "SN1",
+            "sequenceNumber": 102
+        },
+        {
+            "id": 554,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 552,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KING 5",
+            "sequenceNumber": 340
+        },
+        {
+            "id": 388,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "OFF",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 22,
+        "commonName": {
+            "default": "Oilers"
+        },
+        "abbrev": "EDM",
+        "score": 1,
+        "sog": 37,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/EDM_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/EDM_dark.svg",
+        "placeName": {
+            "default": "Edmonton"
+        },
+        "placeNameWithPreposition": {
+            "default": "Edmonton",
+            "fr": "d'Edmonton"
+        }
+    },
+    "homeTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 6,
+        "sog": 37,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 10,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:13",
+            "timeRemaining": "19:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 11,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 30,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8476967
+            }
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:14",
+            "timeRemaining": "19:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:19",
+            "timeRemaining": "19:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 13,
+            "details": {
+                "xCoord": 86,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8476967
+            }
+        },
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:33",
+            "timeRemaining": "19:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 14,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:34",
+            "timeRemaining": "19:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 15,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:34",
+            "timeRemaining": "19:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 18,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8470621,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:46",
+            "timeRemaining": "19:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 19,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:46",
+            "timeRemaining": "19:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 20,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:48",
+            "timeRemaining": "19:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 21,
+            "details": {
+                "xCoord": 48,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:26",
+            "timeRemaining": "18:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 29,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:26",
+            "timeRemaining": "18:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 30,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:47",
+            "timeRemaining": "18:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 32,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:47",
+            "timeRemaining": "18:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 33,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 82,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:06",
+            "timeRemaining": "17:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 35,
+            "details": {
+                "xCoord": -43,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479372
+            }
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 38,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8475906
+            }
+        },
+        {
+            "eventId": 89,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:23",
+            "timeRemaining": "17:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 40,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8479442
+            }
+        },
+        {
+            "eventId": 91,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 43,
+            "details": {
+                "xCoord": 2,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479442,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 83,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:53",
+            "timeRemaining": "17:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 47,
+            "details": {
+                "xCoord": -52,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:03",
+            "timeRemaining": "16:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 50,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:03",
+            "timeRemaining": "16:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 53,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477015,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 97,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:11",
+            "timeRemaining": "16:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 54,
+            "details": {
+                "xCoord": 27,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "playerId": 8480803,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 92,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 55,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 95,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:45",
+            "timeRemaining": "16:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 58,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 2,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 99,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 59,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8483524,
+                "drawnByPlayerId": 8477406,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 63,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 105,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 64,
+            "details": {
+                "xCoord": -19,
+                "yCoord": 2,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8480803,
+                "drawnByPlayerId": 8477955,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 68,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 109,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:09",
+            "timeRemaining": "15:51",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 69,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 111,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 70,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 3,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:52",
+            "timeRemaining": "15:08",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 71,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:52",
+            "timeRemaining": "15:08",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 74,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478042,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 115,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:14",
+            "timeRemaining": "14:46",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 75,
+            "details": {
+                "xCoord": 47,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 116,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:29",
+            "timeRemaining": "14:31",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 4,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 124,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 84,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 141,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:16",
+            "timeRemaining": "13:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 88,
+            "details": {
+                "xCoord": 93,
+                "yCoord": -27,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477498,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 131,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:30",
+            "timeRemaining": "13:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 90,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477406,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:15",
+            "timeRemaining": "12:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 99,
+            "details": {
+                "xCoord": -14,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "typeCode": "BEN",
+                "descKey": "too-many-men-on-the-ice",
+                "duration": 2,
+                "servedByPlayerId": 8481554,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:15",
+            "timeRemaining": "12:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 101,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:15",
+            "timeRemaining": "12:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 104,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475784,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 144,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:23",
+            "timeRemaining": "12:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 105,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 5,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 147,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:13",
+            "timeRemaining": "11:47",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 108,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 6,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:15",
+            "timeRemaining": "11:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 109,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:15",
+            "timeRemaining": "11:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 112,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8481789,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:44",
+            "timeRemaining": "11:16",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 113,
+            "details": {
+                "xCoord": 19,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 118,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "shotType": "snap",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 275,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:50",
+            "timeRemaining": "10:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 126,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8475906,
+                "hitteePlayerId": 8477401
+            }
+        },
+        {
+            "eventId": 272,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:14",
+            "timeRemaining": "09:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 132,
+            "details": {
+                "xCoord": -43,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 7,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 133,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 136,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8474641,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 277,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:17",
+            "timeRemaining": "09:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 137,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8479442,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 290,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:35",
+            "timeRemaining": "09:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 138,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 7,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8480834,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 297,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:50",
+            "timeRemaining": "09:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 139,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479442,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 300,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 140,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477498,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 288,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:10",
+            "timeRemaining": "08:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 141,
+            "details": {
+                "xCoord": 72,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:32",
+            "timeRemaining": "08:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 149,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:32",
+            "timeRemaining": "08:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 150,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:44",
+            "timeRemaining": "08:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 152,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8481617
+            }
+        },
+        {
+            "eventId": 299,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:50",
+            "timeRemaining": "08:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 153,
+            "details": {
+                "xCoord": -29,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8480803
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:53",
+            "timeRemaining": "08:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 154,
+            "details": {
+                "xCoord": -49,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:14",
+            "timeRemaining": "07:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 160,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:14",
+            "timeRemaining": "07:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 162,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8479591,
+                "winningPlayerId": 8474641,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:19",
+            "timeRemaining": "07:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 163,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:25",
+            "timeRemaining": "07:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 164,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:25",
+            "timeRemaining": "07:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 165,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:49",
+            "timeRemaining": "07:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 166,
+            "details": {
+                "xCoord": 30,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:50",
+            "timeRemaining": "07:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 167,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:50",
+            "timeRemaining": "07:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 170,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:52",
+            "timeRemaining": "07:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": 40,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8479372,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 315,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:04",
+            "timeRemaining": "06:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 172,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477406
+            }
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:21",
+            "timeRemaining": "06:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 173,
+            "details": {
+                "xCoord": 40,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477406,
+                "shootingPlayerId": 8477444,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 174,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 177,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 316,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 178,
+            "details": {
+                "xCoord": 56,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 322,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:32",
+            "timeRemaining": "06:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 179,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 27,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477953,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 318,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:53",
+            "timeRemaining": "06:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 181,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:55",
+            "timeRemaining": "06:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 182,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:55",
+            "timeRemaining": "06:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 185,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 334,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 186,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482665,
+                "hitteePlayerId": 8476967
+            }
+        },
+        {
+            "eventId": 333,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:13",
+            "timeRemaining": "05:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 187,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 23,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8476967
+            }
+        },
+        {
+            "eventId": 324,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 189,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 340,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:05",
+            "timeRemaining": "04:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 194,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 331,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 198,
+            "details": {
+                "xCoord": -21,
+                "yCoord": -14,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 8,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:24",
+            "timeRemaining": "04:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 341,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:27",
+            "timeRemaining": "04:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 202,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477955,
+                "hitteePlayerId": 8477015
+            }
+        },
+        {
+            "eventId": 338,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:30",
+            "timeRemaining": "04:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 203,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:35",
+            "timeRemaining": "04:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 204,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8475784,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:37",
+            "timeRemaining": "04:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 205,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:37",
+            "timeRemaining": "04:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 208,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 353,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:52",
+            "timeRemaining": "03:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 216,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 9,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:01",
+            "timeRemaining": "02:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 218,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 202,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:01",
+            "timeRemaining": "02:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 221,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:16",
+            "timeRemaining": "02:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 222,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:16",
+            "timeRemaining": "02:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 223,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 360,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:21",
+            "timeRemaining": "02:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 224,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8475906,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 361,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:28",
+            "timeRemaining": "02:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 225,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 10,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 370,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 226,
+            "details": {
+                "xCoord": -55,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 375,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:38",
+            "timeRemaining": "02:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 227,
+            "details": {
+                "xCoord": -16,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "playerId": 8476454,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 377,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:51",
+            "timeRemaining": "02:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 228,
+            "details": {
+                "xCoord": 3,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477953
+            }
+        },
+        {
+            "eventId": 373,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:25",
+            "timeRemaining": "01:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 239,
+            "details": {
+                "xCoord": 41,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 374,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:29",
+            "timeRemaining": "01:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 240,
+            "details": {
+                "xCoord": 60,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 384,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:44",
+            "timeRemaining": "01:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 241,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8480834,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 386,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:49",
+            "timeRemaining": "01:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 242,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 24,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477406
+            }
+        },
+        {
+            "eventId": 376,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:49",
+            "timeRemaining": "01:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 243,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "deflected",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 389,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:53",
+            "timeRemaining": "01:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 244,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8480834
+            }
+        },
+        {
+            "eventId": 381,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:06",
+            "timeRemaining": "00:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 250,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477015,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 206,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:08",
+            "timeRemaining": "00:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 252,
+            "details": {
+                "reason": "chlg-hm-missed-stoppage",
+                "secondaryReason": "chlg-hm-missed-stoppage"
+            }
+        },
+        {
+            "eventId": 208,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:08",
+            "timeRemaining": "00:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 254,
+            "details": {
+                "reason": "high-stick"
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:08",
+            "timeRemaining": "00:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 255,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477955,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 400,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:17",
+            "timeRemaining": "00:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 256,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8474641
+            }
+        },
+        {
+            "eventId": 391,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:24",
+            "timeRemaining": "00:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 257,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 392,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:32",
+            "timeRemaining": "00:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 258,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 11,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 393,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:42",
+            "timeRemaining": "00:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 259,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 395,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:52",
+            "timeRemaining": "00:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 262,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474641,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 12,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:54",
+            "timeRemaining": "00:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 263,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:54",
+            "timeRemaining": "00:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 266,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8481617,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:57",
+            "timeRemaining": "00:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 267,
+            "details": {
+                "xCoord": -52,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "blockingPlayerId": 8474586,
+                "shootingPlayerId": 8477498,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 209,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 268
+        },
+        {
+            "eventId": 215,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 273
+        },
+        {
+            "eventId": 214,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 276,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 467,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:10",
+            "timeRemaining": "19:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 277,
+            "details": {
+                "xCoord": 20,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8475768,
+                "hitteePlayerId": 8477015
+            }
+        },
+        {
+            "eventId": 454,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:15",
+            "timeRemaining": "19:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 278,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 456,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:36",
+            "timeRemaining": "19:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 279,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 459,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 280,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8477406,
+                "drawnByPlayerId": 8482858,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 159,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 284,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 463,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:46",
+            "timeRemaining": "19:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 285,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 465,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:54",
+            "timeRemaining": "19:06",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 286,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480834,
+                "shootingPlayerId": 8477955,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 217,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 287,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 218,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 289,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8475768,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 469,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 290,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 219,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 291,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 220,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 292,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 471,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 293,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 472,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 294,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 22,
+                "assist1PlayerId": 8477444,
+                "assist1PlayerTotal": 22,
+                "assist2PlayerId": 8477955,
+                "assist2PlayerTotal": 33,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8475717,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-schwartz-scores-goal-against-calvin-pickard-6370664941112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-schwartz-marque-un-but-contre-calvin-pickard-6370665633112",
+                "highlightClip": 6370664941112,
+                "highlightClipFr": 6370665633112,
+                "discreteClip": 6370665237112,
+                "discreteClipFr": 6370665526112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev472.json"
+        },
+        {
+            "eventId": 221,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 298,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477953,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 487,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:29",
+            "timeRemaining": "18:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 299,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 28,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8470621,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 477,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:36",
+            "timeRemaining": "18:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 300,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 222,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:38",
+            "timeRemaining": "18:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 301,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 223,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:38",
+            "timeRemaining": "18:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 302,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 651,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:48",
+            "timeRemaining": "18:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 303,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8470621,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 499,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:05",
+            "timeRemaining": "17:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 305,
+            "details": {
+                "xCoord": -11,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477953,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 483,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:18",
+            "timeRemaining": "17:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 312,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8476967,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 579,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:25",
+            "timeRemaining": "17:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 314,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 491,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:41",
+            "timeRemaining": "17:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 317,
+            "details": {
+                "xCoord": 51,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 13,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 492,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:42",
+            "timeRemaining": "17:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 318,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481617,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 493,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:49",
+            "timeRemaining": "17:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 319,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8475906,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 584,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:56",
+            "timeRemaining": "17:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 320,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 586,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:05",
+            "timeRemaining": "16:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 322,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -18,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 496,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:11",
+            "timeRemaining": "16:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 323,
+            "details": {
+                "xCoord": -4,
+                "yCoord": 32,
+                "zoneCode": "N",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 588,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 326,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8475906
+            }
+        },
+        {
+            "eventId": 554,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 327,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8478013
+            }
+        },
+        {
+            "eventId": 587,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 328,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8478013
+            }
+        },
+        {
+            "eventId": 500,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 329,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 23,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8475717,
+                "awayScore": 0,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-schwartz-scores-goal-against-calvin-pickard-6370665243112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-schwartz-marque-un-but-contre-calvin-pickard-6370664146112",
+                "highlightClip": 6370665243112,
+                "highlightClipFr": 6370664146112,
+                "discreteClip": 6370665242112,
+                "discreteClipFr": 6370663967112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev500.json"
+        },
+        {
+            "eventId": 224,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 332,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 225,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 333,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 226,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:01",
+            "timeRemaining": "15:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 336,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 558,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:23",
+            "timeRemaining": "15:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 337,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 559,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 338,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 14,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 570,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 349,
+            "details": {
+                "xCoord": 42,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481554,
+                "shootingPlayerId": 8475906,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 708,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": 95,
+                "yCoord": -18,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 572,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:22",
+            "timeRemaining": "14:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 351,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 573,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:24",
+            "timeRemaining": "14:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 352,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 574,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:35",
+            "timeRemaining": "14:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475906,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 15,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 575,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:37",
+            "timeRemaining": "14:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 16,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 227,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 355,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 228,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 358,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 582,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:43",
+            "timeRemaining": "14:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 580,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:00",
+            "timeRemaining": "14:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 360,
+            "details": {
+                "xCoord": -70,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 229,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:02",
+            "timeRemaining": "13:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 361,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 230,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:02",
+            "timeRemaining": "13:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 364,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8475768,
+                "winningPlayerId": 8477953,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 592,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:24",
+            "timeRemaining": "13:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478013,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 702,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:42",
+            "timeRemaining": "13:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 369,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478916
+            }
+        },
+        {
+            "eventId": 707,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:44",
+            "timeRemaining": "13:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 370,
+            "details": {
+                "xCoord": 49,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "playerId": 8475768,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 233,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 373,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 709,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:02",
+            "timeRemaining": "12:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 376,
+            "details": {
+                "xCoord": -11,
+                "yCoord": -14,
+                "zoneCode": "N",
+                "playerId": 8481789,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 704,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:03",
+            "timeRemaining": "12:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 377,
+            "details": {
+                "xCoord": -90,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "holding-the-stick",
+                "duration": 2,
+                "committedByPlayerId": 8474586,
+                "drawnByPlayerId": 8480834,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:03",
+            "timeRemaining": "12:57",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 381,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 710,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:16",
+            "timeRemaining": "12:44",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 382,
+            "details": {
+                "xCoord": 34,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 17,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 713,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:16",
+            "timeRemaining": "11:44",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 385,
+            "details": {
+                "xCoord": 35,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 714,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:34",
+            "timeRemaining": "11:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 386,
+            "details": {
+                "xCoord": 42,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 720,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:00",
+            "timeRemaining": "11:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 392,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479372,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 726,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 399,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 732,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:37",
+            "timeRemaining": "10:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 400,
+            "details": {
+                "xCoord": -89,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477498
+            }
+        },
+        {
+            "eventId": 728,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:50",
+            "timeRemaining": "10:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 738,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 404,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 734,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:22",
+            "timeRemaining": "09:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 405,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479591,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 735,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:27",
+            "timeRemaining": "09:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 406,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475906,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 736,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:29",
+            "timeRemaining": "09:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 407,
+            "details": {
+                "xCoord": -88,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 234,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:44",
+            "timeRemaining": "09:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 408,
+            "details": {
+                "reason": "net-dislodged-defensive-skater",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 235,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:44",
+            "timeRemaining": "09:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 411,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478042,
+                "winningPlayerId": 8481554,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 742,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:50",
+            "timeRemaining": "09:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 412,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8483497,
+                "scoringPlayerTotal": 3,
+                "assist1PlayerId": 8476457,
+                "assist1PlayerTotal": 17,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 24,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8475717,
+                "awayScore": 0,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-nyman-scores-goal-against-calvin-pickard-6370664659112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-nyman-marque-un-but-contre-calvin-pickard-6370666711112",
+                "highlightClip": 6370664659112,
+                "highlightClipFr": 6370666711112,
+                "discreteClip": 6370664162112,
+                "discreteClipFr": 6370665541112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev742.json"
+        },
+        {
+            "eventId": 236,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:50",
+            "timeRemaining": "09:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 414,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 745,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 415,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 746,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:03",
+            "timeRemaining": "08:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 747,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:06",
+            "timeRemaining": "08:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 417,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8482665,
+                "scoringPlayerTotal": 18,
+                "assist1PlayerId": 8481554,
+                "assist1PlayerTotal": 27,
+                "assist2PlayerId": 8483497,
+                "assist2PlayerTotal": 3,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8475717,
+                "awayScore": 0,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-beniers-scores-goal-against-calvin-pickard-6370666913112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-beniers-marque-un-but-contre-calvin-pickard-6370664165112",
+                "highlightClip": 6370666913112,
+                "highlightClipFr": 6370664165112,
+                "discreteClip": 6370664553112,
+                "discreteClipFr": 6370667012112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev747.json"
+        },
+        {
+            "eventId": 237,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:06",
+            "timeRemaining": "08:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 420,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477406,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 754,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:13",
+            "timeRemaining": "08:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 421,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8474586
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:20",
+            "timeRemaining": "08:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 422,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476467
+            }
+        },
+        {
+            "eventId": 760,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:40",
+            "timeRemaining": "08:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 423,
+            "details": {
+                "xCoord": 8,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 239,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:51",
+            "timeRemaining": "08:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 426,
+            "details": {
+                "reason": "chlg-vis-off-side",
+                "secondaryReason": "chlg-vis-off-side"
+            }
+        },
+        {
+            "eventId": 241,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:51",
+            "timeRemaining": "08:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 428,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 161,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:51",
+            "timeRemaining": "08:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 431,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8477953,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 761,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:17",
+            "timeRemaining": "07:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 433,
+            "details": {
+                "xCoord": -59,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 768,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:22",
+            "timeRemaining": "07:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 434,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8479442
+            }
+        },
+        {
+            "eventId": 774,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:24",
+            "timeRemaining": "07:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 435,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477953,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 763,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 436,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477444,
+                "scoringPlayerTotal": 8,
+                "assist1PlayerId": 8482858,
+                "assist1PlayerTotal": 20,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8475717,
+                "awayScore": 0,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-burakovsky-scores-goal-against-calvin-pickard-6370664378112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-burakovsky-marque-un-but-contre-calvin-pickard-6370666237112",
+                "highlightClip": 6370664378112,
+                "highlightClipFr": 6370666237112,
+                "discreteClip": 6370666531112,
+                "discreteClipFr": 6370664764112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev763.json"
+        },
+        {
+            "eventId": 242,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 439,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 770,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:25",
+            "timeRemaining": "06:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 440,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8470621,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 18,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 243,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 441,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 244,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 444,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 782,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": 20,
+                "yCoord": -4,
+                "zoneCode": "N",
+                "playerId": 8482665,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 781,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:40",
+            "timeRemaining": "05:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 452,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8475786,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 783,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:54",
+            "timeRemaining": "05:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 453,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8475784,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 245,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:56",
+            "timeRemaining": "05:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 454,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 246,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:56",
+            "timeRemaining": "05:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 459,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8474641,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 795,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:02",
+            "timeRemaining": "04:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 460,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 24,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477953,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 404,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:10",
+            "timeRemaining": "04:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 461,
+            "details": {
+                "xCoord": 88,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8474641,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 791,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 464,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 247,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:45",
+            "timeRemaining": "04:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 465,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 248,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:45",
+            "timeRemaining": "04:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 468,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 249,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:54",
+            "timeRemaining": "04:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 469,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 250,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:54",
+            "timeRemaining": "04:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 471,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 472,
+            "details": {
+                "reason": "high-stick"
+            }
+        },
+        {
+            "eventId": 602,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 474,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477406,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:10",
+            "timeRemaining": "03:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 475,
+            "details": {
+                "reason": "high-stick"
+            }
+        },
+        {
+            "eventId": 163,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:10",
+            "timeRemaining": "03:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 476,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477406,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 804,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:52",
+            "timeRemaining": "03:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 477,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8476967,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 604,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:03",
+            "timeRemaining": "02:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 478,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 806,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:08",
+            "timeRemaining": "02:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 479,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 19,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:11",
+            "timeRemaining": "02:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 480,
+            "details": {
+                "xCoord": 90,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8475786,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 164,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:11",
+            "timeRemaining": "02:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 484,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 605,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:56",
+            "timeRemaining": "02:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 485,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 606,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:56",
+            "timeRemaining": "02:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 488,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:01",
+            "timeRemaining": "01:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 489,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 20,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 818,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 490,
+            "details": {
+                "xCoord": 49,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 21,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 165,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:13",
+            "timeRemaining": "01:47",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 491,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "poke",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 607,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:14",
+            "timeRemaining": "01:46",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 492,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 608,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:14",
+            "timeRemaining": "01:46",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 494,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 821,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:20",
+            "timeRemaining": "01:40",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 22,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 823,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:11",
+            "timeRemaining": "00:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 497,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476454,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 23,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 829,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:27",
+            "timeRemaining": "00:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 501,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8475786,
+                "drawnByPlayerId": 8476467,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 166,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:27",
+            "timeRemaining": "00:33",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 505,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 506,
+            "details": {
+                "xCoord": -32,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8475717,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 609,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 507
+        },
+        {
+            "eventId": 615,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 512
+        },
+        {
+            "eventId": 614,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 515,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477015,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:21",
+            "timeRemaining": "19:39",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 516,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 167,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:57",
+            "timeRemaining": "19:03",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 519,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 851,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:45",
+            "timeRemaining": "18:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 529,
+            "details": {
+                "xCoord": -40,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480834,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 24,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 616,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:47",
+            "timeRemaining": "18:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 530,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 617,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:47",
+            "timeRemaining": "18:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 533,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477406,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 857,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:05",
+            "timeRemaining": "17:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 534,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477498
+            }
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:11",
+            "timeRemaining": "17:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 535,
+            "details": {
+                "xCoord": 36,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 863,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:23",
+            "timeRemaining": "17:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 536,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8475786
+            }
+        },
+        {
+            "eventId": 855,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 537,
+            "details": {
+                "xCoord": -92,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "failed-bank-attempt",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 856,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:37",
+            "timeRemaining": "17:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 538,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 25,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 865,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "17:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 539,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 858,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:48",
+            "timeRemaining": "17:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 540,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 26,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 618,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:51",
+            "timeRemaining": "17:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 541,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 619,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:51",
+            "timeRemaining": "17:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 544,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477953,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 880,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:16",
+            "timeRemaining": "16:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 545,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479372,
+                "hitteePlayerId": 8477953
+            }
+        },
+        {
+            "eventId": 867,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:35",
+            "timeRemaining": "16:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": -33,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 876,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:53",
+            "timeRemaining": "16:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 556,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8479368,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 27,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 652,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 557,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8474641,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 877,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "16:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 558,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8479368,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 168,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:06",
+            "timeRemaining": "15:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 620,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 560,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 621,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 561,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8480009,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 879,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:18",
+            "timeRemaining": "15:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 562,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 893,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:24",
+            "timeRemaining": "15:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 563,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8474641,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 899,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 568,
+            "details": {
+                "xCoord": -62,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8474641
+            }
+        },
+        {
+            "eventId": 885,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:40",
+            "timeRemaining": "15:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 569,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475784,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 28,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 887,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:48",
+            "timeRemaining": "15:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8475786,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 622,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 572,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 623,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 574,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 624,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:53",
+            "timeRemaining": "15:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 575,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:53",
+            "timeRemaining": "15:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 576,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476454,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 892,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:54",
+            "timeRemaining": "15:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 577,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 894,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 578,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475786,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 29,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 895,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:59",
+            "timeRemaining": "15:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 579,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475786,
+                "scoringPlayerTotal": 27,
+                "eventOwnerTeamId": 22,
+                "goalieInNetId": 8478916,
+                "awayScore": 1,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-hyman-scores-goal-against-joey-daccord-6370666947112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-hyman-marque-un-but-contre-joey-daccord-6370667153112",
+                "highlightClip": 6370666947112,
+                "highlightClipFr": 6370667153112,
+                "discreteClip": 6370668032112,
+                "discreteClipFr": 6370665781112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev895.json"
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:59",
+            "timeRemaining": "15:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 582,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 900,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:20",
+            "timeRemaining": "14:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 583,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479442,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 30,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 627,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:32",
+            "timeRemaining": "14:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 584,
+            "details": {
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:40",
+            "timeRemaining": "14:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 585,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8476967,
+                "drawnByPlayerId": 8479591,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 628,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:40",
+            "timeRemaining": "14:20",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 589,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476454,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 911,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:21",
+            "timeRemaining": "13:39",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 593,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 912,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:33",
+            "timeRemaining": "13:27",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 594,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "slap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 915,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 595,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 30,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 916,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 30,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 927,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:16",
+            "timeRemaining": "12:44",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 605,
+            "details": {
+                "xCoord": 21,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 629,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:17",
+            "timeRemaining": "12:43",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 606,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 630,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:17",
+            "timeRemaining": "12:43",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 607,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8482665,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 944,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:26",
+            "timeRemaining": "12:34",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 608,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 17,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8481617,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 941,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:55",
+            "timeRemaining": "12:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 617,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8480803
+            }
+        },
+        {
+            "eventId": 936,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 618,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 942,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 946,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:07",
+            "timeRemaining": "11:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 620,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8475786
+            }
+        },
+        {
+            "eventId": 943,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:09",
+            "timeRemaining": "11:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 621,
+            "details": {
+                "xCoord": -17,
+                "yCoord": -30,
+                "zoneCode": "N",
+                "playerId": 8479591,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 937,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:14",
+            "timeRemaining": "11:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 623,
+            "details": {
+                "xCoord": -52,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480803,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 31,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 631,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:16",
+            "timeRemaining": "11:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 624,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 632,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:16",
+            "timeRemaining": "11:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 627,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476454,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:40",
+            "timeRemaining": "11:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 628,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 947,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:50",
+            "timeRemaining": "11:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 629,
+            "details": {
+                "xCoord": 88,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 31,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 948,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 630,
+            "details": {
+                "xCoord": 81,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "bat",
+                "scoringPlayerId": 8477955,
+                "scoringPlayerTotal": 18,
+                "assist1PlayerId": 8479591,
+                "assist1PlayerTotal": 7,
+                "assist2PlayerId": 8476457,
+                "assist2PlayerTotal": 18,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480885,
+                "awayScore": 1,
+                "homeScore": 6,
+                "highlightClipSharingUrl": "https://nhl.com/video/edm-sea-mccann-scores-goal-against-olivier-rodrigue-6370666170112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/edm-sea-mccann-marque-un-but-contre-olivier-rodrigue-6370665589112",
+                "highlightClip": 6370666170112,
+                "highlightClipFr": 6370665589112,
+                "discreteClip": 6370666280112,
+                "discreteClipFr": 6370665191112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021151/ev948.json"
+        },
+        {
+            "eventId": 633,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 633,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 171,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:37",
+            "timeRemaining": "10:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 634,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 634,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:40",
+            "timeRemaining": "10:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 635,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 635,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:40",
+            "timeRemaining": "10:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 638,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8474641,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 956,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:21",
+            "timeRemaining": "09:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 639,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8478013,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 985,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:28",
+            "timeRemaining": "09:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 640,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8479442
+            }
+        },
+        {
+            "eventId": 966,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:00",
+            "timeRemaining": "09:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 648,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "playerId": 8477401,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 964,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:00",
+            "timeRemaining": "09:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 649,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 636,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:05",
+            "timeRemaining": "08:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 650,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 637,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:05",
+            "timeRemaining": "08:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 652,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:37",
+            "timeRemaining": "08:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 653,
+            "details": {
+                "xCoord": 89,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481789
+            }
+        },
+        {
+            "eventId": 998,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:04",
+            "timeRemaining": "07:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 659,
+            "details": {
+                "xCoord": -93,
+                "yCoord": 31,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 976,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:22",
+            "timeRemaining": "07:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 662,
+            "details": {
+                "xCoord": -32,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475906,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 32,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 638,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:40",
+            "timeRemaining": "07:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 667,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 639,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:40",
+            "timeRemaining": "07:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 670,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8474641,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 986,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:46",
+            "timeRemaining": "07:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 671,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 32,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 172,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 672,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 992,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:34",
+            "timeRemaining": "06:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 673,
+            "details": {
+                "xCoord": 92,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 22,
+                "playerId": 8474641
+            }
+        },
+        {
+            "eventId": 995,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:07",
+            "timeRemaining": "05:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 674,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 988,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 678,
+            "details": {
+                "xCoord": -39,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477015,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 33,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 640,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:15",
+            "timeRemaining": "05:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 680,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 641,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:15",
+            "timeRemaining": "05:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 683,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1101,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:21",
+            "timeRemaining": "05:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 684,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8474586
+            }
+        },
+        {
+            "eventId": 1109,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:43",
+            "timeRemaining": "05:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 685,
+            "details": {
+                "xCoord": -23,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 1113,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:50",
+            "timeRemaining": "05:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 686,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 999,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 687,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 1000,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:55",
+            "timeRemaining": "05:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 688,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8480803,
+                "eventOwnerTeamId": 22,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1102,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 691,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 33,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 643,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 693,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 644,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 696,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477953,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1121,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 697,
+            "details": {
+                "xCoord": 25,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479442,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 1122,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 698,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 17,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479442,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 1126,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:53",
+            "timeRemaining": "04:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 699,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8479442
+            }
+        },
+        {
+            "eventId": 1133,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:55",
+            "timeRemaining": "04:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 700,
+            "details": {
+                "xCoord": 86,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8480834,
+                "hitteePlayerId": 8480009
+            }
+        },
+        {
+            "eventId": 645,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:20",
+            "timeRemaining": "03:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 710,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:20",
+            "timeRemaining": "03:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 711,
+            "details": {
+                "eventOwnerTeamId": 22,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476454,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1123,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:39",
+            "timeRemaining": "03:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 712,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478013,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 34,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 1149,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 713,
+            "details": {
+                "xCoord": -2,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477498,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 1124,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:59",
+            "timeRemaining": "03:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 715,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 35,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 1134,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:07",
+            "timeRemaining": "02:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 716,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477498
+            }
+        },
+        {
+            "eventId": 1139,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:50",
+            "timeRemaining": "02:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 722,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 1135,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:54",
+            "timeRemaining": "02:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 723,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8476967,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22,
+                "awaySOG": 36,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 647,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 724,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 648,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 727,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477406,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 174,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 728,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "bat",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1143,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:44",
+            "timeRemaining": "01:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 732,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8478042,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 22
+            }
+        },
+        {
+            "eventId": 1153,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:15",
+            "timeRemaining": "00:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 740,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476467
+            }
+        },
+        {
+            "eventId": 1158,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:17",
+            "timeRemaining": "00:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 741,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 22,
+                "playerId": 8477953
+            }
+        },
+        {
+            "eventId": 1160,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:27",
+            "timeRemaining": "00:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 742,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8479368,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 1161,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:28",
+            "timeRemaining": "00:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 743,
+            "details": {
+                "xCoord": -28,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 22,
+                "hittingPlayerId": 8477498,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 1155,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 747,
+            "details": {
+                "xCoord": 35,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8480885,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1157,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:52",
+            "timeRemaining": "00:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 748,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478013,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 649,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 749
+        },
+        {
+            "eventId": 1003,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 753
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 22,
+            "playerId": 8470621,
+            "firstName": {
+                "default": "Corey"
+            },
+            "lastName": {
+                "default": "Perry"
+            },
+            "sweaterNumber": 90,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8470621.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8474641,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Henrique"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8474641.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475717,
+            "firstName": {
+                "default": "Calvin"
+            },
+            "lastName": {
+                "default": "Pickard"
+            },
+            "sweaterNumber": 30,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475717.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475784,
+            "firstName": {
+                "default": "Jeff"
+            },
+            "lastName": {
+                "default": "Skinner"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475784.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475786,
+            "firstName": {
+                "default": "Zach"
+            },
+            "lastName": {
+                "default": "Hyman"
+            },
+            "sweaterNumber": 18,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475786.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8475906,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Klingberg"
+            },
+            "sweaterNumber": 36,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8475906.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8476454,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Nugent-Hopkins"
+            },
+            "sweaterNumber": 93,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8476454.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8476967,
+            "firstName": {
+                "default": "Brett"
+            },
+            "lastName": {
+                "default": "Kulak"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8476967.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477015,
+            "firstName": {
+                "default": "Connor"
+            },
+            "lastName": {
+                "default": "Brown"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477015.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477406,
+            "firstName": {
+                "default": "Mattias"
+            },
+            "lastName": {
+                "default": "Janmark"
+            },
+            "sweaterNumber": 13,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477406.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477498,
+            "firstName": {
+                "default": "Darnell"
+            },
+            "lastName": {
+                "default": "Nurse"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477498.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8477953,
+            "firstName": {
+                "default": "Kasperi"
+            },
+            "lastName": {
+                "default": "Kapanen"
+            },
+            "sweaterNumber": 42,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8477953.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8478013,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "Walman"
+            },
+            "sweaterNumber": 96,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8478013.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8478042,
+            "firstName": {
+                "default": "Viktor"
+            },
+            "lastName": {
+                "default": "Arvidsson"
+            },
+            "sweaterNumber": 33,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8478042.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8479368,
+            "firstName": {
+                "default": "Max"
+            },
+            "lastName": {
+                "default": "Jones"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8479368.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479372,
+            "firstName": {
+                "default": "Joshua",
+                "cs": "Josh",
+                "de": "Josh",
+                "es": "Josh",
+                "fi": "Josh",
+                "sk": "Josh",
+                "sv": "Josh"
+            },
+            "lastName": {
+                "default": "Mahura"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479372.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8479442,
+            "firstName": {
+                "default": "Troy"
+            },
+            "lastName": {
+                "default": "Stecher"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8479442.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8480803,
+            "firstName": {
+                "default": "Evan"
+            },
+            "lastName": {
+                "default": "Bouchard"
+            },
+            "sweaterNumber": 2,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8480803.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8480834,
+            "firstName": {
+                "default": "Ty"
+            },
+            "lastName": {
+                "default": "Emberson"
+            },
+            "sweaterNumber": 49,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8480834.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8480885,
+            "firstName": {
+                "default": "Olivier"
+            },
+            "lastName": {
+                "default": "Rodrigue"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8480885.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 22,
+            "playerId": 8481617,
+            "firstName": {
+                "default": "Vasily",
+                "cs": "Vasilij",
+                "fi": "Vasili",
+                "sk": "Vasilij"
+            },
+            "lastName": {
+                "default": "Podkolzin"
+            },
+            "sweaterNumber": 92,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/EDM/8481617.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -90,3 +90,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #70: Seattle Kraken vs Minnesota Wild - Seattle loses 4-0](./2024-25/regular-season/20250319-SEA-vs-MIN-2024021088.json)
 - [GAME #71: Seattle Kraken vs Edmonton Oilers - Seattle loses 5-4](./2024-25/regular-season/20250322-SEA-vs-EDM-2024021116.json)
 - [GAME #72: Seattle Kraken vs Calgary Flames - Seattle loses 4-3 in OT](./2024-25/regular-season/20250325-SEA-vs-CGY-2024021137.json)
+- [GAME #73: Edmonton Oilers vs Seattle Kraken - Seattle wins 6-1](./2024-25/regular-season/20250327-EDM-vs-SEA-2024021151.json)


### PR DESCRIPTION
# Description

Added the JSON data from the Edmonton Oilers vs Seattle Kraken game played on March 27, 2025. The Kraken won 6-1.

- Downloaded game data using the download:nhl:kraken:date script
- Updated the NHL README.md to include Game 73
- Updated .vscode/settings.json to resolve spelling errors from the JSON file

## Type of Change

version: chore     # General maintenance

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] My commits are signed with GPG