### PR TITLE
feat: Add Kraken game #75 vs Dallas Stars (3-1 loss) on March 31, 2025

### DIFF
--- a/data/NHL - National Hockey League/2024-25/regular-season/20250331-DAL-vs-SEA-2024021181.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250331-DAL-vs-SEA-2024021181.json
@@ -1,0 +1,7983 @@
+{
+    "id": 2024021181,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-03-31",
+    "venue": {
+        "default": "Climate Pledge Arena"
+    },
+    "venueLocation": {
+        "default": "Seattle"
+    },
+    "startTimeUTC": "2025-04-01T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 281,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "TVAS",
+            "sequenceNumber": 109
+        },
+        {
+            "id": 554,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 553,
+            "market": "A",
+            "countryCode": "US",
+            "network": "Victory+",
+            "sequenceNumber": 373
+        },
+        {
+            "id": 388,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "OFF",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 25,
+        "commonName": {
+            "default": "Stars"
+        },
+        "abbrev": "DAL",
+        "score": 3,
+        "sog": 31,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/DAL_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/DAL_dark.svg",
+        "placeName": {
+            "default": "Dallas"
+        },
+        "placeNameWithPreposition": {
+            "default": "Dallas",
+            "fr": "de Dallas"
+        }
+    },
+    "homeTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 1,
+        "sog": 36,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482740,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:07",
+            "timeRemaining": "19:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:40",
+            "timeRemaining": "19:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 15,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8476879
+            }
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 18,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8481554,
+                "scoringPlayerTotal": 14,
+                "assist1PlayerId": 8475768,
+                "assist1PlayerTotal": 23,
+                "assist2PlayerId": 8476457,
+                "assist2PlayerTotal": 19,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479193,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/dal-sea-kakko-scores-goal-against-casey-desmith-6370855026112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/dal-sea-kakko-marque-un-but-contre-casey-desmith-6370856389112",
+                "highlightClip": 6370855026112,
+                "highlightClipFr": 6370856389112,
+                "discreteClip": 6370854812112,
+                "discreteClipFr": 6370854627112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021181/ev58.json"
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 20,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 21,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 22,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481581,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:31",
+            "timeRemaining": "18:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 24,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480027,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 80,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:23",
+            "timeRemaining": "17:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 33,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8475798
+            }
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 34,
+            "details": {
+                "xCoord": -45,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8476856,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 75,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 35,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8475168,
+                "scoringPlayerTotal": 29,
+                "assist1PlayerId": 8478975,
+                "assist1PlayerTotal": 22,
+                "assist2PlayerId": 8476856,
+                "assist2PlayerTotal": 7,
+                "eventOwnerTeamId": 25,
+                "goalieInNetId": 8475831,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/dal-sea-duchene-scores-goal-against-philipp-grubauer-6370854444112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/dal-sea-duchene-marque-un-but-contre-philipp-grubauer-6370856891112",
+                "highlightClip": 6370854444112,
+                "highlightClipFr": 6370856891112,
+                "discreteClip": 6370854541112,
+                "discreteClipFr": 6370853949112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021181/ev75.json"
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 38,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482145,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:43",
+            "timeRemaining": "17:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 39,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:43",
+            "timeRemaining": "17:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 40,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8480840,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 88,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:56",
+            "timeRemaining": "17:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 41,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8476879
+            }
+        },
+        {
+            "eventId": 83,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 45,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8482740,
+                "scoringPlayerTotal": 30,
+                "assist1PlayerId": 8476902,
+                "assist1PlayerTotal": 18,
+                "assist2PlayerId": 8480840,
+                "assist2PlayerTotal": 11,
+                "eventOwnerTeamId": 25,
+                "goalieInNetId": 8475831,
+                "awayScore": 2,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/dal-sea-johnston-scores-goal-against-philipp-grubauer-6370853951112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/dal-sea-johnston-marque-un-but-contre-philipp-grubauer-6370854044112",
+                "highlightClip": 6370853951112,
+                "highlightClipFr": 6370854044112,
+                "discreteClip": 6370855119112,
+                "discreteClipFr": 6370856490112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021181/ev83.json"
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 48,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482740,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 49,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 52,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 53,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 54,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 112,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:13",
+            "timeRemaining": "15:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 55,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 30,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8483425
+            }
+        },
+        {
+            "eventId": 99,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:15",
+            "timeRemaining": "15:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 56,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8483425,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 93,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:17",
+            "timeRemaining": "15:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 57,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 94,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:19",
+            "timeRemaining": "15:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 58,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476856,
+                "shootingPlayerId": 8475768,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 116,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:27",
+            "timeRemaining": "15:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 59,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476856
+            }
+        },
+        {
+            "eventId": 100,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:28",
+            "timeRemaining": "15:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 60,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8478449,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 95,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:32",
+            "timeRemaining": "15:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 61,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:34",
+            "timeRemaining": "15:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 62,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:34",
+            "timeRemaining": "15:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 65,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475168,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 140,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 66,
+            "details": {
+                "xCoord": 72,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476879
+            }
+        },
+        {
+            "eventId": 142,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:26",
+            "timeRemaining": "14:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": 11,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "playerId": 8480840
+            }
+        },
+        {
+            "eventId": 120,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:33",
+            "timeRemaining": "14:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 75,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8476902
+            }
+        },
+        {
+            "eventId": 125,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:37",
+            "timeRemaining": "14:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": 33,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8476278
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:42",
+            "timeRemaining": "14:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 78,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482145,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 2,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 110,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:43",
+            "timeRemaining": "14:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 79,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480840,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 3,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 111,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:43",
+            "timeRemaining": "14:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 80,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480840,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 4,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 127,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:43",
+            "timeRemaining": "14:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 81,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8482145
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 82,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480840,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 5,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 143,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:56",
+            "timeRemaining": "14:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 83,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8480840
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 84,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8482145,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:14",
+            "timeRemaining": "13:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 87,
+            "details": {
+                "xCoord": -33,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 117,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:24",
+            "timeRemaining": "13:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 91,
+            "details": {
+                "xCoord": 65,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:40",
+            "timeRemaining": "13:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 93,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:40",
+            "timeRemaining": "13:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 94,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482740,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 126,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:45",
+            "timeRemaining": "13:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 95,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 26,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:32",
+            "timeRemaining": "12:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 105,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:32",
+            "timeRemaining": "12:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 106,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 149,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:34",
+            "timeRemaining": "12:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 107,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8483425
+            }
+        },
+        {
+            "eventId": 144,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 108,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:59",
+            "timeRemaining": "12:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 109,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:59",
+            "timeRemaining": "12:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 112,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475798,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 260,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:19",
+            "timeRemaining": "11:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 113,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476902
+            }
+        },
+        {
+            "eventId": 263,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:27",
+            "timeRemaining": "11:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 114,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 258,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:33",
+            "timeRemaining": "11:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 116,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8475168
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:52",
+            "timeRemaining": "11:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 118,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478975,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 6,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 287,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:29",
+            "timeRemaining": "10:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 125,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 25,
+                "playerId": 8478449
+            }
+        },
+        {
+            "eventId": 262,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:32",
+            "timeRemaining": "10:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 126,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8480950,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 264,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 127,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8478420,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 7,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 265,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:42",
+            "timeRemaining": "10:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 128,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8480950,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 277,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:55",
+            "timeRemaining": "10:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 132,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8480950
+            }
+        },
+        {
+            "eventId": 275,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:06",
+            "timeRemaining": "09:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 140,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476856,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 278,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:33",
+            "timeRemaining": "09:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 141,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474149,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 8,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 279,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:37",
+            "timeRemaining": "09:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 142,
+            "details": {
+                "xCoord": -44,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8476856,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 9,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 300,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:42",
+            "timeRemaining": "09:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 143,
+            "details": {
+                "xCoord": -24,
+                "yCoord": 1,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476856
+            }
+        },
+        {
+            "eventId": 299,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:10",
+            "timeRemaining": "08:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 152,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8476278
+            }
+        },
+        {
+            "eventId": 357,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:50",
+            "timeRemaining": "08:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 162,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "playerId": 8475798,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 354,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:12",
+            "timeRemaining": "07:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 163,
+            "details": {
+                "xCoord": 11,
+                "yCoord": 23,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8478975,
+                "drawnByPlayerId": 8477444,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:12",
+            "timeRemaining": "07:48",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 165,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:12",
+            "timeRemaining": "07:48",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 168,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482740,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 169,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 358,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:43",
+            "timeRemaining": "07:17",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 170,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478449,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 361,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:46",
+            "timeRemaining": "07:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8478449,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:46",
+            "timeRemaining": "07:14",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 175,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475798,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 371,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:11",
+            "timeRemaining": "06:49",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 176,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8483425,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 372,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:51",
+            "timeRemaining": "06:09",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 184,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:53",
+            "timeRemaining": "06:07",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 185,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:53",
+            "timeRemaining": "06:07",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 187,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 381,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 193,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481581,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 10,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 383,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:45",
+            "timeRemaining": "05:15",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 194,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480027,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 11,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 384,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:52",
+            "timeRemaining": "05:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 196,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 394,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 206,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 416,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:13",
+            "timeRemaining": "02:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 222,
+            "details": {
+                "xCoord": -38,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "playerId": 8476278,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 225,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 414,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:40",
+            "timeRemaining": "02:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 226,
+            "details": {
+                "xCoord": 37,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:42",
+            "timeRemaining": "02:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 227,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:42",
+            "timeRemaining": "02:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 230,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 423,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 231,
+            "details": {
+                "xCoord": 55,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 419,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:07",
+            "timeRemaining": "01:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 233,
+            "details": {
+                "xCoord": -60,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481581,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 12,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 421,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:08",
+            "timeRemaining": "01:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 234,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478420,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 430,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:32",
+            "timeRemaining": "01:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 235,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8478420
+            }
+        },
+        {
+            "eventId": 422,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:42",
+            "timeRemaining": "01:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 236,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8480027,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 431,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:10",
+            "timeRemaining": "00:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 244,
+            "details": {
+                "xCoord": -53,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478975,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 13,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 433,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:15",
+            "timeRemaining": "00:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 245,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475798,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 441,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:56",
+            "timeRemaining": "00:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 252,
+            "details": {
+                "xCoord": -42,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8474149,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 253
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 258
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 261,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8473994,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 447,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:13",
+            "timeRemaining": "19:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 262,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 25,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8482740
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:20",
+            "timeRemaining": "19:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 263,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:20",
+            "timeRemaining": "19:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 264,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482740,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:19",
+            "timeRemaining": "18:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 274,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:19",
+            "timeRemaining": "18:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 275,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478420,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 457,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 276,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:25",
+            "timeRemaining": "18:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 277,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:25",
+            "timeRemaining": "18:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 278,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8478449,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 463,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:02",
+            "timeRemaining": "17:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 283,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475168,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 151,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 286,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 288,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475168,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 468,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 289,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 14,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 469,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "17:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 290,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476856,
+                "shootingPlayerId": 8483524,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:49",
+            "timeRemaining": "17:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 291,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 154,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:49",
+            "timeRemaining": "17:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 294,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476278,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 475,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 295,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8474149,
+                "hitteePlayerId": 8477401
+            }
+        },
+        {
+            "eventId": 155,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:13",
+            "timeRemaining": "16:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 296,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:13",
+            "timeRemaining": "16:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 297,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476278,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 474,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:20",
+            "timeRemaining": "16:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 298,
+            "details": {
+                "xCoord": -52,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 476,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:36",
+            "timeRemaining": "16:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 300,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 301,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 304,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8473994,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 484,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:49",
+            "timeRemaining": "16:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 305,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 4,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8473994,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 481,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:21",
+            "timeRemaining": "15:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 306,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 492,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:42",
+            "timeRemaining": "15:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 313,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -22,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8478420,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 489,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:45",
+            "timeRemaining": "15:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 314,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478449,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 15,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 159,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:47",
+            "timeRemaining": "15:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 315,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:47",
+            "timeRemaining": "15:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 317,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8475768,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 161,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 318,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 321,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475168,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 497,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:15",
+            "timeRemaining": "14:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 322,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475798,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 163,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:17",
+            "timeRemaining": "14:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 323,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:21",
+            "timeRemaining": "14:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 324,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8482858,
+                "drawnByPlayerId": 8475798,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 164,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:21",
+            "timeRemaining": "14:39",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 328,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478420,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:46",
+            "timeRemaining": "14:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 329,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 165,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:48",
+            "timeRemaining": "14:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 330,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 166,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:48",
+            "timeRemaining": "14:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 333,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8473994,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 167,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 334,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 168,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 335,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8473994,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 511,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:20",
+            "timeRemaining": "13:40",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 336,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 16,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 551,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:44",
+            "timeRemaining": "13:16",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 337,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8478975,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 169,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:46",
+            "timeRemaining": "13:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 338,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 170,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:46",
+            "timeRemaining": "13:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 341,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8482740,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 552,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 342,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8478420,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 521,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:59",
+            "timeRemaining": "13:01",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 343,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476467
+            }
+        },
+        {
+            "eventId": 515,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:04",
+            "timeRemaining": "12:56",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 344,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478449,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 517,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:22",
+            "timeRemaining": "12:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 346,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481581,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 17,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 171,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:25",
+            "timeRemaining": "12:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 347,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 172,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:25",
+            "timeRemaining": "12:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 350,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480840,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 522,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:27",
+            "timeRemaining": "12:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 351,
+            "details": {
+                "xCoord": 28,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476902,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 523,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:30",
+            "timeRemaining": "12:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 352,
+            "details": {
+                "xCoord": 90,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474149,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 18,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 533,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:53",
+            "timeRemaining": "12:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8474149
+            }
+        },
+        {
+            "eventId": 541,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:09",
+            "timeRemaining": "11:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": -95,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8476879
+            }
+        },
+        {
+            "eventId": 527,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:22",
+            "timeRemaining": "11:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 358,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 19,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 528,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:24",
+            "timeRemaining": "11:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 20,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 173,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:26",
+            "timeRemaining": "11:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 361,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 174,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:26",
+            "timeRemaining": "11:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 364,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475168,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8476856
+            }
+        },
+        {
+            "eventId": 538,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:28",
+            "timeRemaining": "10:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 370,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 653,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:32",
+            "timeRemaining": "10:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 372,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "playerId": 8475768,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 542,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:36",
+            "timeRemaining": "10:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 374,
+            "details": {
+                "xCoord": -46,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 657,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:39",
+            "timeRemaining": "10:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 375,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8475168,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 202,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:50",
+            "timeRemaining": "10:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 376,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 553,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:00",
+            "timeRemaining": "10:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 377,
+            "details": {
+                "xCoord": -33,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 545,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:01",
+            "timeRemaining": "09:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 378,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 546,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:08",
+            "timeRemaining": "09:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 379,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 547,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:08",
+            "timeRemaining": "09:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 380,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 549,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 383,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478975,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 21,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 175,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 386,
+            "details": {
+                "reason": "net-dislodged-offensive-skater",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 554,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 389,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8473994,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 665,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:22",
+            "timeRemaining": "09:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 390,
+            "details": {
+                "xCoord": 7,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477955,
+                "hitteePlayerId": 8480950
+            }
+        },
+        {
+            "eventId": 662,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:56",
+            "timeRemaining": "09:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 393,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "deflected",
+                "shootingPlayerId": 8482145,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 668,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:34",
+            "timeRemaining": "08:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 398,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 21,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 678,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:38",
+            "timeRemaining": "08:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 399,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "playerId": 8478420,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 688,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:30",
+            "timeRemaining": "07:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 409,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8474586,
+                "hitteePlayerId": 8476879
+            }
+        },
+        {
+            "eventId": 693,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:42",
+            "timeRemaining": "07:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 410,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8476278
+            }
+        },
+        {
+            "eventId": 695,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:58",
+            "timeRemaining": "07:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 411,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8476278
+            }
+        },
+        {
+            "eventId": 679,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:59",
+            "timeRemaining": "07:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 412,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480840,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 22,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 680,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:05",
+            "timeRemaining": "06:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 413,
+            "details": {
+                "xCoord": 56,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476879,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 23,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 176,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:07",
+            "timeRemaining": "06:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 414,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 177,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:07",
+            "timeRemaining": "06:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 417,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8475168,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 684,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:09",
+            "timeRemaining": "06:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 418,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8476856,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 685,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 419,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 694,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 420,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8481581
+            }
+        },
+        {
+            "eventId": 687,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 421,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 689,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:55",
+            "timeRemaining": "06:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 422,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 178,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:57",
+            "timeRemaining": "06:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 423,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 179,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:57",
+            "timeRemaining": "06:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 426,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8473994,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 700,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:11",
+            "timeRemaining": "05:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 427,
+            "details": {
+                "xCoord": 12,
+                "yCoord": -34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8482145,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 696,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:44",
+            "timeRemaining": "05:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 428,
+            "details": {
+                "xCoord": -26,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 180,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 429,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 555,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 432,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8474586,
+                "winningPlayerId": 8478449,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:58",
+            "timeRemaining": "05:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 433,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480027,
+                "shootingPlayerId": 8481581,
+                "eventOwnerTeamId": 25,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 702,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 434,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 556,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 435,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 181,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 438,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476278,
+                "winningPlayerId": 8477401,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 708,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:21",
+            "timeRemaining": "04:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 439,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8476856,
+                "drawnByPlayerId": 8483497,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 182,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:21",
+            "timeRemaining": "04:39",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 443,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480840,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 712,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 715,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": -92,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476278
+            }
+        },
+        {
+            "eventId": 714,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:56",
+            "timeRemaining": "04:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 446,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 716,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 447,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 717,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:39",
+            "timeRemaining": "03:21",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 448,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476902,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 183,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:43",
+            "timeRemaining": "03:17",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 449,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 184,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:43",
+            "timeRemaining": "03:17",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 452,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8478449,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 722,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:00",
+            "timeRemaining": "03:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 453,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483425,
+                "shootingPlayerId": 8483497,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 185,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:01",
+            "timeRemaining": "02:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 454,
+            "details": {
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 725,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 455,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8483425,
+                "drawnByPlayerId": 8482665,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 557,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 458,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482740,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 558,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:25",
+            "timeRemaining": "02:35",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 460,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8482740,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 737,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:13",
+            "timeRemaining": "01:47",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 467,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 755,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:53",
+            "timeRemaining": "01:07",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 473,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8482145,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 756,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:17",
+            "timeRemaining": "00:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 479,
+            "details": {
+                "xCoord": -38,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8480950
+            }
+        },
+        {
+            "eventId": 749,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:19",
+            "timeRemaining": "00:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 481,
+            "details": {
+                "xCoord": 7,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 23,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 187,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:32",
+            "timeRemaining": "00:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 486,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 188,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:32",
+            "timeRemaining": "00:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 487,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8477401,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:36",
+            "timeRemaining": "00:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 488,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8480950
+            }
+        },
+        {
+            "eventId": 760,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:49",
+            "timeRemaining": "00:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 489,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8478420
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:51",
+            "timeRemaining": "00:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 490,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "playerId": 8477986,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:59",
+            "timeRemaining": "00:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 491,
+            "details": {
+                "xCoord": -20,
+                "yCoord": 27,
+                "zoneCode": "N",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 189,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 492
+        },
+        {
+            "eventId": 195,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 497
+        },
+        {
+            "eventId": 194,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 500,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 770,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:15",
+            "timeRemaining": "19:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 501,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478407,
+                "hitteePlayerId": 8478449
+            }
+        },
+        {
+            "eventId": 773,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 503,
+            "details": {
+                "xCoord": 95,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8476902
+            }
+        },
+        {
+            "eventId": 772,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:30",
+            "timeRemaining": "19:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 504,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8476902
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:31",
+            "timeRemaining": "19:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 505,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 767,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:43",
+            "timeRemaining": "19:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 508,
+            "details": {
+                "xCoord": -70,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8475168,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 776,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:59",
+            "timeRemaining": "19:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 510,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 25,
+                "playerId": 8475168
+            }
+        },
+        {
+            "eventId": 196,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 511,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 197,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 512,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8475168,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 774,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:09",
+            "timeRemaining": "18:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 513,
+            "details": {
+                "xCoord": -36,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481581,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 514,
+            "details": {
+                "xCoord": -38,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480950,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 24,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 787,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 515,
+            "details": {
+                "xCoord": -88,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 789,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 525,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 24,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 198,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:21",
+            "timeRemaining": "17:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 526,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 199,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:21",
+            "timeRemaining": "17:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 529,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8478449,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 793,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:41",
+            "timeRemaining": "17:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 530,
+            "details": {
+                "xCoord": 18,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 24,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 806,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:25",
+            "timeRemaining": "16:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 540,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8480950
+            }
+        },
+        {
+            "eventId": 807,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:29",
+            "timeRemaining": "16:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 541,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8481581
+            }
+        },
+        {
+            "eventId": 803,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:31",
+            "timeRemaining": "16:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 542,
+            "details": {
+                "xCoord": 58,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481581,
+                "shootingPlayerId": 8483497,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 200,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:32",
+            "timeRemaining": "16:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 543,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:32",
+            "timeRemaining": "16:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 544,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476278,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 815,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 545,
+            "details": {
+                "xCoord": -8,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8480840
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474149,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 25,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 809,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:56",
+            "timeRemaining": "16:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480840,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 26,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 825,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:16",
+            "timeRemaining": "15:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 554,
+            "details": {
+                "xCoord": 14,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "playerId": 8475168
+            }
+        },
+        {
+            "eventId": 827,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:23",
+            "timeRemaining": "15:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 555,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 30,
+                "zoneCode": "D",
+                "playerId": 8478975,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 830,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8475798
+            }
+        },
+        {
+            "eventId": 824,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:07",
+            "timeRemaining": "14:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 565,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 26,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 602,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:09",
+            "timeRemaining": "14:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 566,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 603,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:09",
+            "timeRemaining": "14:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 569,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482740,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 205,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:11",
+            "timeRemaining": "14:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 570,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 831,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:16",
+            "timeRemaining": "14:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482740,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 835,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:50",
+            "timeRemaining": "14:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 572,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 604,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 573,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "slap",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 845,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:25",
+            "timeRemaining": "13:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 583,
+            "details": {
+                "xCoord": 51,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 26,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 584,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480027,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 559,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:49",
+            "timeRemaining": "13:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 585,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 851,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:16",
+            "timeRemaining": "12:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 590,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8478420,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 855,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:33",
+            "timeRemaining": "12:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 594,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476856,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 605,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:35",
+            "timeRemaining": "12:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 595,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 606,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:35",
+            "timeRemaining": "12:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 598,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8475798,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 859,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:38",
+            "timeRemaining": "12:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 599,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8475168,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:41",
+            "timeRemaining": "12:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 600,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476856,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 27,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 861,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:51",
+            "timeRemaining": "12:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 601,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 873,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:18",
+            "timeRemaining": "11:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 602,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8475798
+            }
+        },
+        {
+            "eventId": 869,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:36",
+            "timeRemaining": "11:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 610,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8480840,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 892,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:39",
+            "timeRemaining": "11:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 611,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8476278
+            }
+        },
+        {
+            "eventId": 871,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:01",
+            "timeRemaining": "10:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 612,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479591,
+                "shootingPlayerId": 8476879,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 874,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:12",
+            "timeRemaining": "10:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 616,
+            "details": {
+                "xCoord": 89,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 894,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:34",
+            "timeRemaining": "09:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 630,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 905,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:45",
+            "timeRemaining": "09:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 632,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8483425,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 908,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:47",
+            "timeRemaining": "09:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 633,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 25,
+                "hittingPlayerId": 8478420,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 893,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:53",
+            "timeRemaining": "09:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 634,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 27,
+                "homeSOG": 32
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:04",
+            "timeRemaining": "08:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": 89,
+                "yCoord": 31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 25,
+                "playerId": 8483425
+            }
+        },
+        {
+            "eventId": 608,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:53",
+            "timeRemaining": "08:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 644,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 609,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:53",
+            "timeRemaining": "08:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 647,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 917,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:03",
+            "timeRemaining": "07:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 648,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8476879
+            }
+        },
+        {
+            "eventId": 915,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:39",
+            "timeRemaining": "07:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 655,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480840,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 610,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 656,
+            "details": {
+                "xCoord": 87,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 920,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:52",
+            "timeRemaining": "07:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 657,
+            "details": {
+                "xCoord": 93,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8481581,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 611,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:52",
+            "timeRemaining": "07:08",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 661,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 925,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:18",
+            "timeRemaining": "06:42",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 662,
+            "details": {
+                "xCoord": -28,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478420,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 612,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:21",
+            "timeRemaining": "06:39",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 663,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 613,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:21",
+            "timeRemaining": "06:39",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 666,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482740,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 930,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:51",
+            "timeRemaining": "06:09",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 667,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478449,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25,
+                "awaySOG": 28,
+                "homeSOG": 32
+            }
+        },
+        {
+            "eventId": 614,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:53",
+            "timeRemaining": "06:07",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 668,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 615,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:53",
+            "timeRemaining": "06:07",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 671,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475168,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 934,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:17",
+            "timeRemaining": "05:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 673,
+            "details": {
+                "xCoord": 26,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 936,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:20",
+            "timeRemaining": "05:40",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 674,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "slap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 949,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:04",
+            "timeRemaining": "04:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 686,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8478449,
+                "eventOwnerTeamId": 25,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 955,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:10",
+            "timeRemaining": "04:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 687,
+            "details": {
+                "xCoord": -93,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 25,
+                "playerId": 8480027
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:33",
+            "timeRemaining": "04:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 28,
+                "homeSOG": 33
+            }
+        },
+        {
+            "eventId": 616,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:35",
+            "timeRemaining": "04:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 690,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 617,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:35",
+            "timeRemaining": "04:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 693,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8473994,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 957,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:38",
+            "timeRemaining": "04:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 694,
+            "details": {
+                "xCoord": 35,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 28,
+                "homeSOG": 34
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 699,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475168,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 981,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:39",
+            "timeRemaining": "03:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "playerId": 8476905,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 969,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:52",
+            "timeRemaining": "03:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 706,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 28,
+                "homeSOG": 35
+            }
+        },
+        {
+            "eventId": 983,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:07",
+            "timeRemaining": "02:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 708,
+            "details": {
+                "xCoord": -49,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 985,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:15",
+            "timeRemaining": "02:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 711,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 976,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:15",
+            "timeRemaining": "02:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 712,
+            "details": {
+                "xCoord": -16,
+                "yCoord": -30,
+                "zoneCode": "N",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8481581,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 618,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:31",
+            "timeRemaining": "02:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 719,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 619,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:31",
+            "timeRemaining": "02:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 721,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8482740,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 987,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:06",
+            "timeRemaining": "01:54",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 723,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 995,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:09",
+            "timeRemaining": "01:51",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 724,
+            "details": {
+                "xCoord": 91,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "playerId": 8481554,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:25",
+            "timeRemaining": "01:35",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 725,
+            "details": {
+                "xCoord": 37,
+                "yCoord": -23,
+                "zoneCode": "D",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482145,
+                "eventOwnerTeamId": 25
+            }
+        },
+        {
+            "eventId": 992,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:53",
+            "timeRemaining": "01:07",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 729,
+            "details": {
+                "xCoord": 45,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475798,
+                "scoringPlayerTotal": 20,
+                "assist1PlayerId": 8476902,
+                "assist1PlayerTotal": 19,
+                "assist2PlayerId": 8478975,
+                "assist2PlayerTotal": 23,
+                "eventOwnerTeamId": 25,
+                "awayScore": 3,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/dal-sea-granlund-scores-goal-against-philipp-grubauer-6370858943112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/dal-sea-granlund-dal-marque-un-but-dans-un-filet-desert-6370857867112",
+                "highlightClip": 6370858943112,
+                "highlightClipFr": 6370857867112,
+                "discreteClip": 6370859722112,
+                "discreteClipFr": 6370858738112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021181/ev992.json"
+        },
+        {
+            "eventId": 560,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:53",
+            "timeRemaining": "01:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 732,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 620,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:26",
+            "timeRemaining": "00:34",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 734,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "home-timeout"
+            }
+        },
+        {
+            "eventId": 622,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:26",
+            "timeRemaining": "00:34",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 735,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478449,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 623,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:33",
+            "timeRemaining": "00:27",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 736,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 624,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:33",
+            "timeRemaining": "00:27",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 737,
+            "details": {
+                "eventOwnerTeamId": 25,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8478449,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 206,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:55",
+            "timeRemaining": "00:05",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 738,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479193,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 739
+        },
+        {
+            "eventId": 629,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 743
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 25,
+            "playerId": 8473994,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Benn"
+            },
+            "sweaterNumber": 14,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8473994.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8474149,
+            "firstName": {
+                "default": "Evgenii",
+                "cs": "Jevgenij",
+                "fi": "Jevgeni",
+                "sk": "Jevgenij"
+            },
+            "lastName": {
+                "default": "Dadonov"
+            },
+            "sweaterNumber": 63,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8474149.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8475168,
+            "firstName": {
+                "default": "Matt"
+            },
+            "lastName": {
+                "default": "Duchene"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8475168.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8475798,
+            "firstName": {
+                "default": "Mikael"
+            },
+            "lastName": {
+                "default": "Granlund"
+            },
+            "sweaterNumber": 64,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8475798.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8476278,
+            "firstName": {
+                "default": "Colin"
+            },
+            "lastName": {
+                "default": "Blackwell"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8476278.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8476856,
+            "firstName": {
+                "default": "Mathew",
+                "cs": "Matt",
+                "de": "Matt",
+                "es": "Matt",
+                "fi": "Matt",
+                "sk": "Matt",
+                "sv": "Matt"
+            },
+            "lastName": {
+                "default": "Dumba"
+            },
+            "sweaterNumber": 3,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8476856.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8476879,
+            "firstName": {
+                "default": "Cody"
+            },
+            "lastName": {
+                "default": "Ceci"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8476879.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8476902,
+            "firstName": {
+                "default": "Esa"
+            },
+            "lastName": {
+                "default": "Lindell"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8476902.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476905.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8478420,
+            "firstName": {
+                "default": "Mikko"
+            },
+            "lastName": {
+                "default": "Rantanen"
+            },
+            "sweaterNumber": 96,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8478420.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8478449,
+            "firstName": {
+                "default": "Roope"
+            },
+            "lastName": {
+                "default": "Hintz"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8478449.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8478975,
+            "firstName": {
+                "default": "Mason"
+            },
+            "lastName": {
+                "default": "Marchment"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8478975.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8479193,
+            "firstName": {
+                "default": "Casey"
+            },
+            "lastName": {
+                "default": "DeSmith"
+            },
+            "sweaterNumber": 1,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8479193.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8479979,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "Oettinger"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8479979.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479985,
+            "firstName": {
+                "default": "Cale"
+            },
+            "lastName": {
+                "default": "Fleury"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479985.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8480027,
+            "firstName": {
+                "default": "Jason"
+            },
+            "lastName": {
+                "default": "Robertson"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8480027.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8480840,
+            "firstName": {
+                "default": "Oskar"
+            },
+            "lastName": {
+                "default": "B\u00e4ck"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8480840.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8480950,
+            "firstName": {
+                "default": "Ilya",
+                "cs": "Ilja",
+                "fi": "Ilja",
+                "sk": "I\u013eja"
+            },
+            "lastName": {
+                "default": "Lyubushkin",
+                "cs": "Ljubu\u0161kin",
+                "fi": "Ljubushkin",
+                "sk": "Ljubu\u0161kin"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8480950.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8481581,
+            "firstName": {
+                "default": "Thomas"
+            },
+            "lastName": {
+                "default": "Harley"
+            },
+            "sweaterNumber": 55,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8481581.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8482145,
+            "firstName": {
+                "default": "Mavrik"
+            },
+            "lastName": {
+                "default": "Bourque"
+            },
+            "sweaterNumber": 22,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8482145.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8482740,
+            "firstName": {
+                "default": "Wyatt"
+            },
+            "lastName": {
+                "default": "Johnston"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8482740.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 25,
+            "playerId": 8483425,
+            "firstName": {
+                "default": "Lian"
+            },
+            "lastName": {
+                "default": "Bichsel"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/DAL/8483425.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -92,3 +92,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #72: Seattle Kraken vs Calgary Flames - Seattle loses 4-3 in OT](./2024-25/regular-season/20250325-SEA-vs-CGY-2024021137.json)
 - [GAME #73: Edmonton Oilers vs Seattle Kraken - Seattle wins 6-1](./2024-25/regular-season/20250327-EDM-vs-SEA-2024021151.json)
 - [GAME #74: Dallas Stars vs Seattle Kraken - Seattle loses 5-1](./2024-25/regular-season/20250329-DAL-vs-SEA-2024021169.json)
+- [GAME #75: Dallas Stars vs Seattle Kraken - Seattle loses 3-1](./2024-25/regular-season/20250331-DAL-vs-SEA-2024021181.json)


### PR DESCRIPTION
# Description

This PR adds the latest Seattle Kraken game data from March 31, 2025, where the Kraken lost 3-1 to the Dallas Stars. The following changes were made:

- Downloaded game data JSON file for Game 75
- Updated the NHL README.md file to include the game result

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] My commits are signed with GPG