### PR TITLE
feat: Add Kraken vs Canucks game from April 2, 2025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1110,6 +1110,7 @@
     "Leevi",
     "Legwold",
     "Lehkonen",
+    "Lekkerim",
     "Lekkerimaki",
     "Lemieux",
     "Lemire",

--- a/data/NHL - National Hockey League/2024-25/regular-season/20250402-SEA-vs-VAN-2024021196.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250402-SEA-vs-VAN-2024021196.json
@@ -1,0 +1,7090 @@
+{
+    "id": 2024021196,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-04-02",
+    "venue": {
+        "default": "Rogers Arena"
+    },
+    "venueLocation": {
+        "default": "Vancouver"
+    },
+    "startTimeUTC": "2025-04-03T02:30:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 290,
+            "market": "H",
+            "countryCode": "CA",
+            "network": "SNP",
+            "sequenceNumber": 33
+        },
+        {
+            "id": 291,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "TVAS2",
+            "sequenceNumber": 110
+        },
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 552,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KING 5",
+            "sequenceNumber": 340
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 5,
+        "sog": 19,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 23,
+        "commonName": {
+            "default": "Canucks"
+        },
+        "abbrev": "VAN",
+        "score": 0,
+        "sog": 24,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/VAN_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/VAN_dark.svg",
+        "placeName": {
+            "default": "Vancouver"
+        },
+        "placeNameWithPreposition": {
+            "default": "Vancouver",
+            "fr": "de Vancouver"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 52,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 51,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 104,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:22",
+            "timeRemaining": "19:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 13,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 151,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 16,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 118,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 17,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478444,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 131,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:37",
+            "timeRemaining": "19:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 18,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 23,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8479425,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 139,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 29,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8474574,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 119,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 30,
+            "details": {
+                "xCoord": 42,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482055,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 122,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:45",
+            "timeRemaining": "18:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 33,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478856,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 127,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:55",
+            "timeRemaining": "18:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 36,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "holding",
+                "duration": 2,
+                "committedByPlayerId": 8476467,
+                "drawnByPlayerId": 8478856,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:55",
+            "timeRemaining": "18:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 40,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 132,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 41,
+            "details": {
+                "xCoord": -52,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 148,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:01",
+            "timeRemaining": "16:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 48,
+            "details": {
+                "xCoord": -27,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480800
+            }
+        },
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:06",
+            "timeRemaining": "16:54",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 49,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 141,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:23",
+            "timeRemaining": "16:37",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 51,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "blockingPlayerId": 8481024,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 61,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 63,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:24",
+            "timeRemaining": "15:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 66,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 212,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:55",
+            "timeRemaining": "15:05",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 73,
+            "details": {
+                "xCoord": -44,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 0,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:56",
+            "timeRemaining": "15:04",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480459,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 0,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 213,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 75,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480459,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 216,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:00",
+            "timeRemaining": "15:00",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 14,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8479591,
+                "drawnByPlayerId": 8482691,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 154,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:00",
+            "timeRemaining": "15:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 80,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 220,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:02",
+            "timeRemaining": "14:58",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 81,
+            "details": {
+                "xCoord": -56,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 222,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:17",
+            "timeRemaining": "14:43",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 82,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 0,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:18",
+            "timeRemaining": "14:42",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 83,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 0,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 224,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:48",
+            "timeRemaining": "14:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 85,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 245,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:30",
+            "timeRemaining": "13:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 92,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -33,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8480748
+            }
+        },
+        {
+            "eventId": 231,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:38",
+            "timeRemaining": "13:22",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 93,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 233,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:45",
+            "timeRemaining": "13:15",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 94,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 237,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:53",
+            "timeRemaining": "13:07",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 98,
+            "details": {
+                "xCoord": -49,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 1,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 99,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 155,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 102,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 242,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:04",
+            "timeRemaining": "12:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 104,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "blockingPlayerId": 8478057,
+                "shootingPlayerId": 8478856,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:17",
+            "timeRemaining": "12:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 105,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:20",
+            "timeRemaining": "12:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 106,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:20",
+            "timeRemaining": "12:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 109,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:18",
+            "timeRemaining": "11:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 117,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474574,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 1,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 265,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:41",
+            "timeRemaining": "11:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 118,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8482496
+            }
+        },
+        {
+            "eventId": 273,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:44",
+            "timeRemaining": "11:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 119,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8481024
+            }
+        },
+        {
+            "eventId": 255,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:47",
+            "timeRemaining": "11:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 120,
+            "details": {
+                "xCoord": -1,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 269,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:01",
+            "timeRemaining": "10:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 128,
+            "details": {
+                "xCoord": 93,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8477969
+            }
+        },
+        {
+            "eventId": 272,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:12",
+            "timeRemaining": "10:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 131,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478498,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:28",
+            "timeRemaining": "10:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 132,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:28",
+            "timeRemaining": "10:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 135,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482691,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 270,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:37",
+            "timeRemaining": "10:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 136,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:51",
+            "timeRemaining": "10:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 137,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8478057,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 138,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 140,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482055,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 141,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 159,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 143,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 281,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:34",
+            "timeRemaining": "09:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 147,
+            "details": {
+                "xCoord": -64,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 289,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:41",
+            "timeRemaining": "09:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 148,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480459,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 287,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 154,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8474574,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 294,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:08",
+            "timeRemaining": "08:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 156,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8474574,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 296,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 157,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 356,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:20",
+            "timeRemaining": "08:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 158,
+            "details": {
+                "xCoord": -91,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:21",
+            "timeRemaining": "08:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 159,
+            "details": {
+                "xCoord": -34,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474574,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 290,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:27",
+            "timeRemaining": "08:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 160,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8474574,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 3,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:29",
+            "timeRemaining": "08:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 161,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:29",
+            "timeRemaining": "08:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 164,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 295,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:44",
+            "timeRemaining": "08:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 165,
+            "details": {
+                "xCoord": 28,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 355,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:47",
+            "timeRemaining": "08:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 166,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 300,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:57",
+            "timeRemaining": "08:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": 43,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 363,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:56",
+            "timeRemaining": "07:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 179,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:14",
+            "timeRemaining": "06:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 184,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 55,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:14",
+            "timeRemaining": "06:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 186,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482055,
+                "winningPlayerId": 8483524,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 378,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:41",
+            "timeRemaining": "06:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 189,
+            "details": {
+                "xCoord": -99,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476927,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 370,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:49",
+            "timeRemaining": "06:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 190,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8474574,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 371,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:55",
+            "timeRemaining": "06:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 191,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 375,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:56",
+            "timeRemaining": "06:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 192,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "interference-goalkeeper",
+                "duration": 2,
+                "committedByPlayerId": 8476927,
+                "drawnByPlayerId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 56,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:56",
+            "timeRemaining": "06:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 196,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 381,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 198,
+            "details": {
+                "xCoord": 60,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 388,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:49",
+            "timeRemaining": "05:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 203,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 6,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 204,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 161,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 207,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 398,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:24",
+            "timeRemaining": "04:36",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 209,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 405,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:46",
+            "timeRemaining": "04:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 211,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478856,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:37",
+            "timeRemaining": "03:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 223,
+            "details": {
+                "xCoord": 11,
+                "yCoord": 5,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8478498
+            }
+        },
+        {
+            "eventId": 407,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:42",
+            "timeRemaining": "03:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 224,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8479591,
+                "scoringPlayerTotal": 8,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8477967,
+                "awayScore": 1,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-eyssimont-scores-goal-against-thatcher-demko-6370957477112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-eyssimont-marque-un-but-contre-thatcher-demko-6370959018112",
+                "highlightClip": 6370957477112,
+                "highlightClipFr": 6370959018112,
+                "discreteClip": 6370959412112,
+                "discreteClipFr": 6370956361112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021196/ev407.json"
+        },
+        {
+            "eventId": 57,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:42",
+            "timeRemaining": "03:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 227,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 422,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:48",
+            "timeRemaining": "03:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 228,
+            "details": {
+                "xCoord": 18,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "playerId": 8474574,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 420,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:16",
+            "timeRemaining": "02:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 231,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 421,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:23",
+            "timeRemaining": "02:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 232,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 233,
+            "details": {
+                "reason": "hand-pass",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 236,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480748,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 432,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:43",
+            "timeRemaining": "02:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 237,
+            "details": {
+                "xCoord": 21,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 431,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:30",
+            "timeRemaining": "01:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 245,
+            "details": {
+                "xCoord": -37,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 447,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:42",
+            "timeRemaining": "00:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 256,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8478498
+            }
+        },
+        {
+            "eventId": 448,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:47",
+            "timeRemaining": "00:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 257,
+            "details": {
+                "xCoord": 22,
+                "yCoord": 20,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8474574,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 261
+        },
+        {
+            "eventId": 60,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 266
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 269,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 565,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:50",
+            "timeRemaining": "19:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 275,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8483678
+            }
+        },
+        {
+            "eventId": 563,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:19",
+            "timeRemaining": "18:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 282,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 568,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:51",
+            "timeRemaining": "18:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 286,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 569,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:59",
+            "timeRemaining": "18:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 287,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8478444,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 575,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 293,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 579,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 294,
+            "details": {
+                "xCoord": -70,
+                "yCoord": 5,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8475762,
+                "drawnByPlayerId": 8477401,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 298,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 591,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:15",
+            "timeRemaining": "16:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 301,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -42,
+                "zoneCode": "D",
+                "playerId": 8476927,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 585,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:27",
+            "timeRemaining": "16:33",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 304,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:30",
+            "timeRemaining": "16:30",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 305,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 163,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:30",
+            "timeRemaining": "16:30",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 308,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 593,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:26",
+            "timeRemaining": "15:34",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 309,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 598,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:44",
+            "timeRemaining": "15:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 315,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "blockingPlayerId": 8478856,
+                "shootingPlayerId": 8474574,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:53",
+            "timeRemaining": "15:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 316,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 61,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:53",
+            "timeRemaining": "15:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 318,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 603,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:09",
+            "timeRemaining": "14:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 320,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8483678,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 604,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:16",
+            "timeRemaining": "14:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 321,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481024,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 605,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:17",
+            "timeRemaining": "14:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 322,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481024,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 8,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 606,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:18",
+            "timeRemaining": "14:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 323,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481024,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 621,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:30",
+            "timeRemaining": "14:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 324,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 608,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:45",
+            "timeRemaining": "14:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 326,
+            "details": {
+                "xCoord": 60,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 8,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 623,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:18",
+            "timeRemaining": "13:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 335,
+            "details": {
+                "xCoord": -33,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8479425
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 336,
+            "details": {
+                "xCoord": 45,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 622,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:25",
+            "timeRemaining": "13:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 337,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 617,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:31",
+            "timeRemaining": "13:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 338,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480800,
+                "shootingPlayerId": 8482751,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 624,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:31",
+            "timeRemaining": "13:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 339,
+            "details": {
+                "xCoord": -12,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478057,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:33",
+            "timeRemaining": "13:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 340,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 164,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:33",
+            "timeRemaining": "13:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 343,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 636,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:39",
+            "timeRemaining": "13:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 344,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8479425,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 650,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:10",
+            "timeRemaining": "12:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 345,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480459,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 638,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:36",
+            "timeRemaining": "12:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": -43,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 651,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:47",
+            "timeRemaining": "11:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 364,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 665,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:55",
+            "timeRemaining": "11:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481024,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:24",
+            "timeRemaining": "10:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 368,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:24",
+            "timeRemaining": "10:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 370,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:27",
+            "timeRemaining": "10:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 371,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 660,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:49",
+            "timeRemaining": "10:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 375,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8476905,
+                "scoringPlayerTotal": 12,
+                "assist1PlayerId": 8477444,
+                "assist1PlayerTotal": 24,
+                "assist2PlayerId": 8477955,
+                "assist2PlayerTotal": 35,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8477967,
+                "awayScore": 2,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-stephenson-scores-goal-against-thatcher-demko-6370959850112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-stephenson-marque-un-but-contre-thatcher-demko-6370958285112",
+                "highlightClip": 6370959850112,
+                "highlightClipFr": 6370958285112,
+                "discreteClip": 6370958773112,
+                "discreteClipFr": 6370959747112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021196/ev660.json"
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:49",
+            "timeRemaining": "10:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 378,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480459,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 666,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:11",
+            "timeRemaining": "09:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 379,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480800,
+                "shootingPlayerId": 8477444,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 687,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:23",
+            "timeRemaining": "09:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 381,
+            "details": {
+                "xCoord": 93,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478498,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 670,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:37",
+            "timeRemaining": "09:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 383,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8483678,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 672,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:44",
+            "timeRemaining": "09:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 386,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479425,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 683,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 394,
+            "details": {
+                "xCoord": 0,
+                "yCoord": 18,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8479591,
+                "drawnByPlayerId": 8482055,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 396,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 399,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8478444,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 688,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:40",
+            "timeRemaining": "08:20",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 400,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 689,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:52",
+            "timeRemaining": "08:08",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 691,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:06",
+            "timeRemaining": "07:54",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 403,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 306,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:08",
+            "timeRemaining": "07:52",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 404,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 696,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:32",
+            "timeRemaining": "07:28",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 410,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478498,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 414,
+            "details": {
+                "xCoord": 88,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478856,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 702,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8481024,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 705,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:12",
+            "timeRemaining": "06:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 418,
+            "details": {
+                "xCoord": 45,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 706,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:22",
+            "timeRemaining": "06:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 419,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8480748,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 420,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 423,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478057,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 714,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:47",
+            "timeRemaining": "06:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 425,
+            "details": {
+                "xCoord": 42,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8477986,
+                "drawnByPlayerId": 8478057,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 717,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:47",
+            "timeRemaining": "06:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 427,
+            "details": {
+                "xCoord": 45,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "closing-hand-on-puck",
+                "duration": 2,
+                "committedByPlayerId": 8478057,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 66,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:47",
+            "timeRemaining": "06:13",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 431,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 725,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:45",
+            "timeRemaining": "05:15",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 437,
+            "details": {
+                "xCoord": 44,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 439,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 67,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 442,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8478444,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 730,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:47",
+            "timeRemaining": "05:13",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 443,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 744,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:06",
+            "timeRemaining": "04:54",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480800
+            }
+        },
+        {
+            "eventId": 731,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:20",
+            "timeRemaining": "04:40",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:23",
+            "timeRemaining": "04:37",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 446,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 68,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:23",
+            "timeRemaining": "04:37",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 449,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480459,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 777,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:29",
+            "timeRemaining": "04:31",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 450,
+            "details": {
+                "xCoord": 87,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480459
+            }
+        },
+        {
+            "eventId": 740,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:00",
+            "timeRemaining": "04:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 456,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8483524,
+                "scoringPlayerTotal": 18,
+                "assist1PlayerId": 8477955,
+                "assist1PlayerTotal": 36,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 25,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8477967,
+                "awayScore": 3,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-wright-scores-goal-against-thatcher-demko-6370959870112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-wright-marque-un-but-contre-thatcher-demko-6370960836112",
+                "highlightClip": 6370959870112,
+                "highlightClipFr": 6370960836112,
+                "discreteClip": 6370958782112,
+                "discreteClipFr": 6370959350112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021196/ev740.json"
+        },
+        {
+            "eventId": 69,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:00",
+            "timeRemaining": "04:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 459,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 748,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:07",
+            "timeRemaining": "03:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 460,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8481024
+            }
+        },
+        {
+            "eventId": 746,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:45",
+            "timeRemaining": "03:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 462,
+            "details": {
+                "xCoord": 33,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 749,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:55",
+            "timeRemaining": "03:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 464,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 767,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:19",
+            "timeRemaining": "02:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 471,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478057,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 790,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:26",
+            "timeRemaining": "02:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 472,
+            "details": {
+                "xCoord": -55,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8474574
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:28",
+            "timeRemaining": "02:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 473,
+            "details": {
+                "xCoord": -64,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:39",
+            "timeRemaining": "02:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 475,
+            "details": {
+                "xCoord": -28,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 760,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:54",
+            "timeRemaining": "02:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 478,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8482055,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 787,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:07",
+            "timeRemaining": "01:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 481,
+            "details": {
+                "xCoord": 1,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476927,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 765,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:13",
+            "timeRemaining": "01:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 484,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 791,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:16",
+            "timeRemaining": "01:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 485,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "playerId": 8476927
+            }
+        },
+        {
+            "eventId": 789,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:25",
+            "timeRemaining": "01:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 486,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482055,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:00",
+            "timeRemaining": "01:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 494,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8480459,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 776,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:06",
+            "timeRemaining": "00:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480459,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 792,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:43",
+            "timeRemaining": "00:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 503,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "playerId": 8480748,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 785,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:46",
+            "timeRemaining": "00:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 504,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8477969,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 786,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:56",
+            "timeRemaining": "00:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 505,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 506
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 511
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 514,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 795,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:07",
+            "timeRemaining": "19:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 515,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477969,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 801,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:30",
+            "timeRemaining": "19:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 516,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:34",
+            "timeRemaining": "19:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 517,
+            "details": {
+                "xCoord": -91,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:35",
+            "timeRemaining": "19:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 518,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:50",
+            "timeRemaining": "19:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 519,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476905,
+                "shootingPlayerId": 8478057,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:58",
+            "timeRemaining": "19:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 520,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8480748,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 799,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 521,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478057,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:23",
+            "timeRemaining": "17:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 538,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 165,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:23",
+            "timeRemaining": "17:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 541,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482496,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:58",
+            "timeRemaining": "17:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 542,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477444,
+                "hitteePlayerId": 8483678
+            }
+        },
+        {
+            "eventId": 825,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:16",
+            "timeRemaining": "16:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 545,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482496,
+                "shootingPlayerId": 8477969,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 827,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:26",
+            "timeRemaining": "16:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 23,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 829,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:28",
+            "timeRemaining": "16:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 550,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483476,
+                "shootingPlayerId": 8477401,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:34",
+            "timeRemaining": "16:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 552,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 840,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:40",
+            "timeRemaining": "16:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 837,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 557,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8479425,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 839,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:55",
+            "timeRemaining": "16:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 558,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 843,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:16",
+            "timeRemaining": "15:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 560,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 908,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:23",
+            "timeRemaining": "15:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 561,
+            "details": {
+                "xCoord": 90,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8479425,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:45",
+            "timeRemaining": "15:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 563,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 310,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:25",
+            "timeRemaining": "14:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 574,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:26",
+            "timeRemaining": "14:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 575,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "backhand",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:28",
+            "timeRemaining": "14:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 576,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 910,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:28",
+            "timeRemaining": "14:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 577,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8483678,
+                "drawnByPlayerId": 8483497,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 914,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:28",
+            "timeRemaining": "14:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 579,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8483497,
+                "drawnByPlayerId": 8483678,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 72,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:28",
+            "timeRemaining": "14:32",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 583,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 917,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:03",
+            "timeRemaining": "13:57",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 584,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8474574,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 928,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:28",
+            "timeRemaining": "12:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 595,
+            "details": {
+                "xCoord": -35,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 13,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:31",
+            "timeRemaining": "12:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 597,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 166,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:31",
+            "timeRemaining": "12:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 600,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 939,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:44",
+            "timeRemaining": "12:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 601,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483678,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 933,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:46",
+            "timeRemaining": "12:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 602,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 510,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:54",
+            "timeRemaining": "12:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 603,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476905,
+                "goalieInNetId": 8477967,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 940,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:30",
+            "timeRemaining": "11:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 607,
+            "details": {
+                "xCoord": -71,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8480459,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:33",
+            "timeRemaining": "11:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 608,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:36",
+            "timeRemaining": "11:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 609,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 167,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:36",
+            "timeRemaining": "11:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 612,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 944,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:39",
+            "timeRemaining": "11:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 613,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482691,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 946,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:55",
+            "timeRemaining": "11:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 614,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477444,
+                "scoringPlayerTotal": 9,
+                "assist1PlayerId": 8477955,
+                "assist1PlayerTotal": 37,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8477967,
+                "awayScore": 4,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-burakovsky-scores-goal-against-thatcher-demko-6370961463112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-burakovsky-marque-un-but-contre-thatcher-demko-6370961949112",
+                "highlightClip": 6370961463112,
+                "highlightClipFr": 6370961949112,
+                "discreteClip": 6370961385112,
+                "discreteClipFr": 6370960499112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021196/ev946.json"
+        },
+        {
+            "eventId": 73,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:55",
+            "timeRemaining": "11:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 617,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482496,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 950,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:14",
+            "timeRemaining": "10:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 618,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:15",
+            "timeRemaining": "10:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 619,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 168,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:15",
+            "timeRemaining": "10:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 621,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 962,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 622,
+            "details": {
+                "xCoord": -1,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481024,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:52",
+            "timeRemaining": "10:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 624,
+            "details": {
+                "xCoord": 46,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "playerId": 8480800,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:04",
+            "timeRemaining": "09:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 631,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477969,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 989,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:09",
+            "timeRemaining": "09:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 633,
+            "details": {
+                "xCoord": 58,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "playerId": 8482055
+            }
+        },
+        {
+            "eventId": 981,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:22",
+            "timeRemaining": "09:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8482055
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:29",
+            "timeRemaining": "09:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 636,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478856,
+                "shootingPlayerId": 8474586,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 964,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:35",
+            "timeRemaining": "09:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 637,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "blockingPlayerId": 8476905,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 999,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:57",
+            "timeRemaining": "09:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 647,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8480459
+            }
+        },
+        {
+            "eventId": 977,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:26",
+            "timeRemaining": "08:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 650,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8479425,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1009,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:39",
+            "timeRemaining": "08:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 655,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 1017,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:42",
+            "timeRemaining": "08:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 656,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8480748
+            }
+        },
+        {
+            "eventId": 986,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:50",
+            "timeRemaining": "08:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 661,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478057,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 1023,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:56",
+            "timeRemaining": "08:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 662,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478057,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 1028,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:08",
+            "timeRemaining": "07:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8482691
+            }
+        },
+        {
+            "eventId": 1031,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:20",
+            "timeRemaining": "07:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 668,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8483476
+            }
+        },
+        {
+            "eventId": 1005,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 678,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8478856,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1033,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:35",
+            "timeRemaining": "06:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 684,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8478856
+            }
+        },
+        {
+            "eventId": 1032,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:19",
+            "timeRemaining": "05:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 694,
+            "details": {
+                "xCoord": 3,
+                "yCoord": 9,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 1026,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:29",
+            "timeRemaining": "05:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 698,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8479425,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:31",
+            "timeRemaining": "05:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 699,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:32",
+            "timeRemaining": "05:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 700,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 169,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:32",
+            "timeRemaining": "05:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 703,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1034,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": -71,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8483678,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1035,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:47",
+            "timeRemaining": "05:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 705,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 1037,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 706,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477955,
+                "shootingPlayerId": 8483678,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:03",
+            "timeRemaining": "04:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 707,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:03",
+            "timeRemaining": "04:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 708,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8478057,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 170,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:03",
+            "timeRemaining": "04:57",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 712,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480459,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 313,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 713,
+            "details": {
+                "xCoord": -59,
+                "yCoord": -27,
+                "zoneCode": "D",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 714,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 171,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 715,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1042,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:17",
+            "timeRemaining": "04:43",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 716,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "blockingPlayerId": 8478498,
+                "shootingPlayerId": 8480459,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 503,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:26",
+            "timeRemaining": "04:34",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 717,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 172,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:26",
+            "timeRemaining": "04:34",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 718,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480459,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1050,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:38",
+            "timeRemaining": "04:22",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 719,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 1048,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 723,
+            "details": {
+                "xCoord": 45,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8476457,
+                "scoringPlayerTotal": 7,
+                "assist1PlayerId": 8481789,
+                "assist1PlayerTotal": 5,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 26,
+                "eventOwnerTeamId": 55,
+                "awayScore": 5,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-larsson-scores-empty-net-goal-6370960806112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-larsson-sea-marque-un-but-dans-un-filet-desert-6370960609112",
+                "highlightClip": 6370960806112,
+                "highlightClipFr": 6370960609112,
+                "discreteClip": 6370962656112,
+                "discreteClipFr": 6370961401112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021196/ev1048.json"
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 726,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482496,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 504,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 727,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 173,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 729,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1067,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:58",
+            "timeRemaining": "03:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 730,
+            "details": {
+                "xCoord": -90,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8482055
+            }
+        },
+        {
+            "eventId": 1081,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:59",
+            "timeRemaining": "03:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 731,
+            "details": {
+                "xCoord": -91,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 1055,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:00",
+            "timeRemaining": "03:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 732,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8480748,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1056,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:07",
+            "timeRemaining": "02:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 733,
+            "details": {
+                "xCoord": -29,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477969,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 1085,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:37",
+            "timeRemaining": "02:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 740,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483497
+            }
+        },
+        {
+            "eventId": 1089,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:27",
+            "timeRemaining": "01:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 753,
+            "details": {
+                "xCoord": -61,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479985
+            }
+        },
+        {
+            "eventId": 1076,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:32",
+            "timeRemaining": "01:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 754,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8478856,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1090,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:01",
+            "timeRemaining": "00:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 759,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8476927
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 765
+        },
+        {
+            "eventId": 509,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 769
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 23,
+            "playerId": 8474574,
+            "firstName": {
+                "default": "Tyler"
+            },
+            "lastName": {
+                "default": "Myers"
+            },
+            "sweaterNumber": 57,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8474574.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8475762,
+            "firstName": {
+                "default": "Derek"
+            },
+            "lastName": {
+                "default": "Forbort"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8475762.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476905.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8476927,
+            "firstName": {
+                "default": "Teddy",
+                "cs": "Theodors",
+                "sk": "Theodors"
+            },
+            "lastName": {
+                "default": "Blueger",
+                "cs": "Blugers",
+                "sk": "Blugers"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8476927.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8477967,
+            "firstName": {
+                "default": "Thatcher"
+            },
+            "lastName": {
+                "default": "Demko"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8477967.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8477969,
+            "firstName": {
+                "default": "Marcus"
+            },
+            "lastName": {
+                "default": "Pettersson"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8477969.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478057,
+            "firstName": {
+                "default": "Dakota"
+            },
+            "lastName": {
+                "default": "Joshua"
+            },
+            "sweaterNumber": 81,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8478057.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478444,
+            "firstName": {
+                "default": "Brock"
+            },
+            "lastName": {
+                "default": "Boeser"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8478444.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478498,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "DeBrusk"
+            },
+            "sweaterNumber": 74,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8478498.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478856,
+            "firstName": {
+                "default": "Conor"
+            },
+            "lastName": {
+                "default": "Garland"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8478856.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8479425,
+            "firstName": {
+                "default": "Filip"
+            },
+            "lastName": {
+                "default": "Hronek"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8479425.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479985,
+            "firstName": {
+                "default": "Cale"
+            },
+            "lastName": {
+                "default": "Fleury"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479985.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480459,
+            "firstName": {
+                "default": "Pius"
+            },
+            "lastName": {
+                "default": "Suter"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8480459.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480748,
+            "firstName": {
+                "default": "Kiefer"
+            },
+            "lastName": {
+                "default": "Sherwood"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8480748.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480800,
+            "firstName": {
+                "default": "Quinn"
+            },
+            "lastName": {
+                "default": "Hughes"
+            },
+            "sweaterNumber": 43,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8480800.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480947,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Lankinen"
+            },
+            "sweaterNumber": 32,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8480947.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8481024,
+            "firstName": {
+                "default": "Linus"
+            },
+            "lastName": {
+                "default": "Karlsson"
+            },
+            "sweaterNumber": 94,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8481024.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482055,
+            "firstName": {
+                "default": "Drew"
+            },
+            "lastName": {
+                "default": "O'Connor"
+            },
+            "sweaterNumber": 18,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8482055.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482496,
+            "firstName": {
+                "default": "Nils"
+            },
+            "lastName": {
+                "default": "Aman",
+                "fi": "\u00c5man",
+                "sv": "\u00c5man"
+            },
+            "sweaterNumber": 88,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8482496.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482691,
+            "firstName": {
+                "default": "Aatu"
+            },
+            "lastName": {
+                "default": "Raty",
+                "cs": "R\u00e4ty",
+                "fi": "R\u00e4ty",
+                "sk": "R\u00e4ty",
+                "sv": "R\u00e4ty"
+            },
+            "sweaterNumber": 54,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8482691.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482751,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Winterton"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482751.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483476,
+            "firstName": {
+                "default": "Jonathan"
+            },
+            "lastName": {
+                "default": "Lekkerim\u00e4ki"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8483476.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483678,
+            "firstName": {
+                "default": "Elias"
+            },
+            "lastName": {
+                "default": "Pettersson"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/VAN/8483678.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -93,3 +93,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #73: Edmonton Oilers vs Seattle Kraken - Seattle wins 6-1](./2024-25/regular-season/20250327-EDM-vs-SEA-2024021151.json)
 - [GAME #74: Dallas Stars vs Seattle Kraken - Seattle loses 5-1](./2024-25/regular-season/20250329-DAL-vs-SEA-2024021169.json)
 - [GAME #75: Dallas Stars vs Seattle Kraken - Seattle loses 3-1](./2024-25/regular-season/20250331-DAL-vs-SEA-2024021181.json)
+- [GAME #76: Seattle Kraken vs Vancouver Canucks - Seattle wins 5-0](./2024-25/regular-season/20250402-SEA-vs-VAN-2024021196.json)


### PR DESCRIPTION
# Description

Add Seattle Kraken vs Vancouver Canucks game from April 2, 2025 (5-0 win) to the NHL data collection.

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] My commits are signed with GPG