### PR TITLE
chore: Update WHL playoff README formatting and add helper scripts

### DIFF
--- a/data/WHL - Western Hockey League/README.md
+++ b/data/WHL - Western Hockey League/README.md
@@ -92,4 +92,4 @@ Play By Play:
 - [ROUND 1 GAME #1: 2025.03.28 Seattle wins 3-2 against Everett Silvertips](./2024-25/playoffs/20250328-SEA-vs-EVT-1021961-pxpverbose.json)
 - [ROUND 1 GAME #2: 2025.03.29 Seattle loses 3-2 against Everett Silvertips in OT](./2024-25/playoffs/20250329-SEA-vs-EVT-1021962-pxpverbose.json)
 - [ROUND 1 GAME #3: 2025.04.01 Seattle wins 6-3 against Everett Silvertips](./2024-25/playoffs/20250401-EVT-vs-SEA-1021969-pxpverbose.json)
-- [ROUND 1 GAME #4: 2025-04-04 Seattle loses 6-2 against Everett Silvertips](./2024-25/playoffs/20250404-EVT-vs-SEA-1021970-pxpverbose.json)
+- [ROUND 1 GAME #4: 2025.04.04 Seattle loses 6-2 against Everett Silvertips](./2024-25/playoffs/20250404-EVT-vs-SEA-1021970-pxpverbose.json)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "download:tbirds": "npm run download:whl:tbirds",
     "download:whl:tbirds": "./src/download_whl.sh",
     "download:whl:tbirds:date": "./src/download_whl.sh thunderbirds 2025-02-15",
+    "download:whl:playoffs": "./src/download_whl_playoff_game.sh",
+    "download:whl:playoffs:date": "./src/download_whl_playoff_game.sh 2025-04-05",
     "test": "npm run test:workflows",
     "test:workflows": "chmod +x .github/test-workflows.sh && .github/test-workflows.sh",
     "test:workflows:semantic": "act pull_request -e .github/test-data/pr-events/minor.json -W .github/workflows/semantic-pr-check.yml",


### PR DESCRIPTION
# Description

This PR updates the WHL playoff README to use consistent date formatting (YYYY.MM.DD) and adds npm scripts for downloading WHL playoff games.

Changes:
- Fixed date format in WHL README for playoff games to consistently use YYYY.MM.DD format
- Added npm scripts to package.json for downloading WHL playoff games:
  - download:whl:playoffs: Downloads today's playoff game data
  - download:whl:playoffs:date: Downloads playoff game data for a specific date

## Type of Change

version: chore    # General maintenance

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
