### PR TITLE
feat: Add Kraken game #77 from April 5, 2025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1337,6 +1337,7 @@
     "Nazar",
     "Nazem",
     "NBAE",
+    "NBCSCA",
     "NBCSP",
     "NCAAF",
     "ncommerce",

--- a/data/NHL - National Hockey League/2024-25/regular-season/20250405-SEA-vs-SJS-2024021221.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250405-SEA-vs-SJS-2024021221.json
@@ -1,0 +1,7368 @@
+{
+    "id": 2024021221,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-04-05",
+    "venue": {
+        "default": "SAP Center at San Jose"
+    },
+    "venueLocation": {
+        "default": "San Jose"
+    },
+    "startTimeUTC": "2025-04-06T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 314,
+            "market": "H",
+            "countryCode": "US",
+            "network": "NBCSCA",
+            "sequenceNumber": 384
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "OFF",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 5,
+        "sog": 22,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 28,
+        "commonName": {
+            "default": "Sharks"
+        },
+        "abbrev": "SJS",
+        "score": 1,
+        "sog": 24,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SJS_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SJS_dark.svg",
+        "placeName": {
+            "default": "San Jose"
+        },
+        "placeNameWithPreposition": {
+            "default": "San Jose",
+            "fr": "de San Jose"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 52,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 51,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 110,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:15",
+            "timeRemaining": "19:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 103,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 13,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8480043,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:59",
+            "timeRemaining": "19:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 18,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:59",
+            "timeRemaining": "19:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 19,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 111,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:09",
+            "timeRemaining": "18:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 21,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 124,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:28",
+            "timeRemaining": "18:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 28,
+                "playerId": 8481567
+            }
+        },
+        {
+            "eventId": 115,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:33",
+            "timeRemaining": "18:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 25,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 118,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:48",
+            "timeRemaining": "18:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 29,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479336,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 0,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 136,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:55",
+            "timeRemaining": "18:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 31,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 121,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:56",
+            "timeRemaining": "18:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 32,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483481,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 0,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:58",
+            "timeRemaining": "18:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 33,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 55,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:58",
+            "timeRemaining": "18:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 35,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480848,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 56,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:08",
+            "timeRemaining": "17:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 36,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482144,
+                "shootingPlayerId": 8483497,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:40",
+            "timeRemaining": "17:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 43,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -18,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8482859,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 135,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:12",
+            "timeRemaining": "16:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 47,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8479393,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 202,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:27",
+            "timeRemaining": "16:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 50,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8480043,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 140,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:27",
+            "timeRemaining": "16:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 51,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482667,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 0,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:30",
+            "timeRemaining": "16:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 52,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 57,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:30",
+            "timeRemaining": "16:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 54,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477505,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 57,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8471709,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 0,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:13",
+            "timeRemaining": "15:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 58,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 58,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:13",
+            "timeRemaining": "15:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 61,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 161,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:18",
+            "timeRemaining": "15:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 62,
+            "details": {
+                "xCoord": 40,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483497
+            }
+        },
+        {
+            "eventId": 149,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:22",
+            "timeRemaining": "15:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 63,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 167,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:52",
+            "timeRemaining": "15:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 64,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 168,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:56",
+            "timeRemaining": "15:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 65,
+            "details": {
+                "xCoord": -9,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "playerId": 8484227
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479372,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:24",
+            "timeRemaining": "14:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 76,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:24",
+            "timeRemaining": "14:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 77,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480848,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 261,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:27",
+            "timeRemaining": "14:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 78,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -15,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479336,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 163,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:46",
+            "timeRemaining": "14:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 79,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477955,
+                "scoringPlayerTotal": 19,
+                "assist1PlayerId": 8477444,
+                "assist1PlayerTotal": 25,
+                "assist2PlayerId": 8479372,
+                "assist2PlayerTotal": 9,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480382,
+                "awayScore": 1,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-mccann-scores-goal-against-alexandar-georgiev-6371118543112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-mccann-marque-un-but-contre-alexandar-georgiev-6371118233112",
+                "highlightClip": 6371118543112,
+                "highlightClipFr": 6371118233112,
+                "discreteClip": 6371120107112,
+                "discreteClipFr": 6371117850112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev163.json"
+        },
+        {
+            "eventId": 60,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:46",
+            "timeRemaining": "14:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 82,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 272,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:53",
+            "timeRemaining": "14:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 83,
+            "details": {
+                "xCoord": -11,
+                "yCoord": -12,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8479393
+            }
+        },
+        {
+            "eventId": 281,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:59",
+            "timeRemaining": "14:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 84,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8482859,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 169,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:00",
+            "timeRemaining": "14:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 85,
+            "details": {
+                "xCoord": 36,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479983,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 182,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:09",
+            "timeRemaining": "13:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 86,
+            "details": {
+                "xCoord": 40,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 28,
+                "playerId": 8480043
+            }
+        },
+        {
+            "eventId": 170,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 87,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 171,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:28",
+            "timeRemaining": "13:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 88,
+            "details": {
+                "xCoord": -44,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479393,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 180,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:44",
+            "timeRemaining": "13:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 96,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 31,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:49",
+            "timeRemaining": "13:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 98,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 61,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:49",
+            "timeRemaining": "13:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 99,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 195,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:02",
+            "timeRemaining": "12:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 100,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 28,
+                "playerId": 8481567
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:16",
+            "timeRemaining": "12:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 101,
+            "details": {
+                "xCoord": -47,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479523,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 256,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:43",
+            "timeRemaining": "12:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 109,
+            "details": {
+                "xCoord": 26,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 190,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:48",
+            "timeRemaining": "12:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 110,
+            "details": {
+                "xCoord": 48,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8484227,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 2,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 191,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:53",
+            "timeRemaining": "12:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 111,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "slap",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 192,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:08",
+            "timeRemaining": "11:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 112,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 196,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:23",
+            "timeRemaining": "11:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 115,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482144,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:55",
+            "timeRemaining": "11:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 123,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 255,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 124,
+            "details": {
+                "xCoord": -36,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479336,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 125,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8477444,
+                "scoringPlayerTotal": 10,
+                "assist1PlayerId": 8476457,
+                "assist1PlayerTotal": 20,
+                "assist2PlayerId": 8477955,
+                "assist2PlayerTotal": 38,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480382,
+                "awayScore": 2,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-burakovsky-scores-goal-against-alexandar-georgiev-6371119820112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-burakovsky-marque-un-but-contre-alexandar-georgiev-6371119513112",
+                "highlightClip": 6371119820112,
+                "highlightClipFr": 6371119513112,
+                "discreteClip": 6371119821112,
+                "discreteClipFr": 6371119041112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev257.json"
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 128,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482667,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 265,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:46",
+            "timeRemaining": "10:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 129,
+            "details": {
+                "xCoord": 31,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8477401,
+                "drawnByPlayerId": 8477505,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:46",
+            "timeRemaining": "10:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 131,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:46",
+            "timeRemaining": "10:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 134,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 270,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:24",
+            "timeRemaining": "09:36",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 136,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 4,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 271,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:25",
+            "timeRemaining": "09:35",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 137,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 4,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 282,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:44",
+            "timeRemaining": "09:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 139,
+            "details": {
+                "xCoord": 28,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 28,
+                "playerId": 8484801
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:07",
+            "timeRemaining": "08:53",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 144,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:07",
+            "timeRemaining": "08:53",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 147,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8483481,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 285,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:22",
+            "timeRemaining": "08:38",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 148,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8479336,
+                "drawnByPlayerId": 8479372,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:22",
+            "timeRemaining": "08:38",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 152,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482667,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 297,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:38",
+            "timeRemaining": "07:22",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 160,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479983,
+                "shootingPlayerId": 8476905,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 161,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 68,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:41",
+            "timeRemaining": "07:19",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 164,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480848,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 166,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 169,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480848,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:31",
+            "timeRemaining": "06:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479336,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:41",
+            "timeRemaining": "06:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 175,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 316,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:00",
+            "timeRemaining": "06:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 179,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480043,
+                "shootingPlayerId": 8475768,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 318,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:16",
+            "timeRemaining": "05:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 181,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 5,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 319,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:18",
+            "timeRemaining": "05:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 182,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8484227,
+                "scoringPlayerTotal": 14,
+                "assist1PlayerId": 8475726,
+                "assist1PlayerTotal": 22,
+                "assist2PlayerId": 8484801,
+                "assist2PlayerTotal": 34,
+                "eventOwnerTeamId": 28,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-smith-scores-goal-against-joey-daccord-6371120118112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-smith-marque-un-but-contre-joey-daccord-6371117759112",
+                "highlightClip": 6371120118112,
+                "highlightClipFr": 6371117759112,
+                "discreteClip": 6371120405112,
+                "discreteClipFr": 6371120024112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev319.json"
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:18",
+            "timeRemaining": "05:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 184,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 336,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 185,
+            "details": {
+                "xCoord": -93,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 28,
+                "playerId": 8482144
+            }
+        },
+        {
+            "eventId": 339,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:45",
+            "timeRemaining": "05:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 186,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483497
+            }
+        },
+        {
+            "eventId": 328,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:12",
+            "timeRemaining": "04:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 193,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8471709,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:57",
+            "timeRemaining": "04:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 200,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8479523,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 338,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:07",
+            "timeRemaining": "03:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484911,
+                "shootingPlayerId": 8480043,
+                "eventOwnerTeamId": 28,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 340,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 202,
+            "details": {
+                "xCoord": 31,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480043,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 5,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:18",
+            "timeRemaining": "03:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 203,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 72,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:18",
+            "timeRemaining": "03:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 206,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 381,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 207,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8477955
+            }
+        },
+        {
+            "eventId": 355,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:50",
+            "timeRemaining": "03:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 208,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 28,
+                "playerId": 8479523
+            }
+        },
+        {
+            "eventId": 364,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:22",
+            "timeRemaining": "02:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 218,
+            "details": {
+                "xCoord": -91,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8474586
+            }
+        },
+        {
+            "eventId": 382,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:30",
+            "timeRemaining": "02:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 219,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476905,
+                "hitteePlayerId": 8484801
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 220,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 5,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 221,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 73,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 224,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:12",
+            "timeRemaining": "01:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 230,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:12",
+            "timeRemaining": "01:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 231,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477505,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 365,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:21",
+            "timeRemaining": "01:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 232,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8479523,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 369,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:55",
+            "timeRemaining": "01:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 235,
+            "details": {
+                "xCoord": 37,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479523,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 5,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 370,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:04",
+            "timeRemaining": "00:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 236,
+            "details": {
+                "xCoord": 89,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482667,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:06",
+            "timeRemaining": "00:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 237,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 75,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:06",
+            "timeRemaining": "00:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 240,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 383,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:12",
+            "timeRemaining": "00:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 241,
+            "details": {
+                "xCoord": 30,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8480009
+            }
+        },
+        {
+            "eventId": 375,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:43",
+            "timeRemaining": "00:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 242,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 247
+        },
+        {
+            "eventId": 77,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 252
+        },
+        {
+            "eventId": 76,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 255,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 386,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:10",
+            "timeRemaining": "19:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 256,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8477505,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:13",
+            "timeRemaining": "19:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 257,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 78,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:13",
+            "timeRemaining": "19:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 258,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477505,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 388,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:15",
+            "timeRemaining": "19:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 259,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482144,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 6,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:18",
+            "timeRemaining": "19:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 260,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 79,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:18",
+            "timeRemaining": "19:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 261,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:31",
+            "timeRemaining": "19:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 262,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 80,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:31",
+            "timeRemaining": "19:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 264,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 397,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:04",
+            "timeRemaining": "18:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 271,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 398,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:05",
+            "timeRemaining": "18:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 272,
+            "details": {
+                "xCoord": 88,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 576,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 281,
+            "details": {
+                "xCoord": -39,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479336,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 568,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:09",
+            "timeRemaining": "17:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 282,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 593,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:28",
+            "timeRemaining": "17:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 287,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 292,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 81,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 294,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 569,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:11",
+            "timeRemaining": "16:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 295,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 572,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:28",
+            "timeRemaining": "16:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 300,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 581,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:40",
+            "timeRemaining": "16:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 301,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "playerId": 8476467,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:50",
+            "timeRemaining": "16:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 302,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 82,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:50",
+            "timeRemaining": "16:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 303,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 585,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 311,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8477505,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 590,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:40",
+            "timeRemaining": "15:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 313,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8481554,
+                "drawnByPlayerId": 8477505,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 83,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:40",
+            "timeRemaining": "15:20",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 317,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8484801,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:44",
+            "timeRemaining": "15:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 318,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "playerId": 8477505,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 597,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 319,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8484227,
+                "drawnByPlayerId": 8480009,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 84,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 323,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 602,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:23",
+            "timeRemaining": "14:37",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 324,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 607,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:56",
+            "timeRemaining": "14:04",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 329,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 610,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 332,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479983,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 613,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:39",
+            "timeRemaining": "13:21",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 335,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8479523,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 628,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:08",
+            "timeRemaining": "12:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 344,
+            "details": {
+                "xCoord": 39,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:15",
+            "timeRemaining": "12:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 347,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8483481,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 658,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:20",
+            "timeRemaining": "12:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 349,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479336,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:30",
+            "timeRemaining": "12:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": -47,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479336,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:39",
+            "timeRemaining": "12:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 351,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8476905,
+                "scoringPlayerTotal": 13,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480382,
+                "awayScore": 3,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-stephenson-scores-goal-against-alexandar-georgiev-6371120253112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-stephenson-marque-un-but-contre-alexandar-georgiev-6371119262112",
+                "highlightClip": 6371120253112,
+                "highlightClipFr": 6371119262112,
+                "discreteClip": 6371119263112,
+                "discreteClipFr": 6371121614112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev626.json"
+        },
+        {
+            "eventId": 85,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:39",
+            "timeRemaining": "12:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 354,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 631,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:51",
+            "timeRemaining": "12:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 355,
+            "details": {
+                "xCoord": -27,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481567,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 668,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:55",
+            "timeRemaining": "12:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 356,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8482859,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 632,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 357,
+            "details": {
+                "xCoord": -30,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8471709,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 6,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:05",
+            "timeRemaining": "11:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 358,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 86,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:05",
+            "timeRemaining": "11:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 361,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476624,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 636,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:15",
+            "timeRemaining": "11:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 362,
+            "details": {
+                "xCoord": 44,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 637,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:27",
+            "timeRemaining": "11:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 363,
+            "details": {
+                "xCoord": -56,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482859,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 6,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:29",
+            "timeRemaining": "11:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 364,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:29",
+            "timeRemaining": "11:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 367,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:35",
+            "timeRemaining": "11:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 368,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 88,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:35",
+            "timeRemaining": "11:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 369,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 642,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:47",
+            "timeRemaining": "11:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 370,
+            "details": {
+                "xCoord": 59,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 660,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:54",
+            "timeRemaining": "11:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 371,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 14,
+                "zoneCode": "D",
+                "playerId": 8477986,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 643,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 372,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 373,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 644,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:11",
+            "timeRemaining": "10:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 374,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8480382,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 662,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:19",
+            "timeRemaining": "10:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 375,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 695,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:29",
+            "timeRemaining": "10:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 376,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8479523
+            }
+        },
+        {
+            "eventId": 649,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:56",
+            "timeRemaining": "10:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 379,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 31,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484227,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 7,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:12",
+            "timeRemaining": "09:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 387,
+            "details": {
+                "xCoord": 57,
+                "yCoord": 23,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482667,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:14",
+            "timeRemaining": "09:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 388,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 89,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:14",
+            "timeRemaining": "09:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 391,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8477505,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 682,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:18",
+            "timeRemaining": "08:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": 26,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8474586
+            }
+        },
+        {
+            "eventId": 673,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:25",
+            "timeRemaining": "08:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 403,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479336,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 676,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:36",
+            "timeRemaining": "08:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 405,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 24,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480382,
+                "awayScore": 4,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-schwartz-scores-goal-against-alexandar-georgiev-6371121523112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-schwartz-marque-un-but-contre-alexandar-georgiev-6371120536112",
+                "highlightClip": 6371121523112,
+                "highlightClipFr": 6371120536112,
+                "discreteClip": 6371119083112,
+                "discreteClipFr": 6371120444112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev676.json"
+        },
+        {
+            "eventId": 90,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:36",
+            "timeRemaining": "08:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 408,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482859,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 409,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 91,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 411,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482859,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 736,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:54",
+            "timeRemaining": "08:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 412,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -8,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479393,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 453,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:57",
+            "timeRemaining": "08:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 413,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479983,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:24",
+            "timeRemaining": "07:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 416,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 92,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:24",
+            "timeRemaining": "07:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 419,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8484801,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 752,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:32",
+            "timeRemaining": "07:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 420,
+            "details": {
+                "xCoord": -95,
+                "yCoord": 23,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8484227,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 692,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:54",
+            "timeRemaining": "07:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 421,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 22,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8480043,
+                "drawnByPlayerId": 8482665,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 93,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:54",
+            "timeRemaining": "07:06",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 425,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476624,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 696,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:20",
+            "timeRemaining": "06:40",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 426,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 710,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 440,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 712,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:07",
+            "timeRemaining": "04:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 442,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 443,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 94,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 446,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 716,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 447,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475726,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 726,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:31",
+            "timeRemaining": "04:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 448,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 718,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:31",
+            "timeRemaining": "04:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 449,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 8,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:33",
+            "timeRemaining": "04:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 450,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 95,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:33",
+            "timeRemaining": "04:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 452,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477505,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 745,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:08",
+            "timeRemaining": "03:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 457,
+            "details": {
+                "xCoord": 11,
+                "yCoord": 35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "playerId": 8479983
+            }
+        },
+        {
+            "eventId": 727,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:18",
+            "timeRemaining": "03:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 458,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 753,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 465,
+            "details": {
+                "xCoord": 90,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 28,
+                "playerId": 8484312
+            }
+        },
+        {
+            "eventId": 734,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:55",
+            "timeRemaining": "03:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 466,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481567,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:03",
+            "timeRemaining": "02:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 468,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "playerId": 8482665,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 746,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:50",
+            "timeRemaining": "02:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 476,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483497,
+                "shootingPlayerId": 8484227,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 748,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:07",
+            "timeRemaining": "01:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 480,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477955,
+                "scoringPlayerTotal": 20,
+                "assist1PlayerId": 8483524,
+                "assist1PlayerTotal": 24,
+                "assist2PlayerId": 8481554,
+                "assist2PlayerTotal": 28,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8484312,
+                "awayScore": 5,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-sjs-mccann-scores-goal-against-georgi-romanov-6371120943112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-sjs-mccann-marque-un-but-contre-georgi-romanov-6371121042112",
+                "highlightClip": 6371120943112,
+                "highlightClipFr": 6371121042112,
+                "discreteClip": 6371121142112,
+                "discreteClipFr": 6371119881112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021221/ev748.json"
+        },
+        {
+            "eventId": 96,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:07",
+            "timeRemaining": "01:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 483,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8477505,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 756,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:14",
+            "timeRemaining": "01:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 484,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:32",
+            "timeRemaining": "01:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 485,
+            "details": {
+                "xCoord": -28,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8482144,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 771,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:49",
+            "timeRemaining": "01:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 486,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -12,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8479983,
+                "hitteePlayerId": 8477955
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:05",
+            "timeRemaining": "00:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 490,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 97,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:05",
+            "timeRemaining": "00:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 493,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 765,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:19",
+            "timeRemaining": "00:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 494,
+            "details": {
+                "xCoord": -49,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480043,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 772,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:31",
+            "timeRemaining": "00:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 500
+        },
+        {
+            "eventId": 99,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 505
+        },
+        {
+            "eventId": 98,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 508,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477505,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 777,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:37",
+            "timeRemaining": "19:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 509,
+            "details": {
+                "xCoord": 92,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8476457,
+                "drawnByPlayerId": 8484911,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 100,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:37",
+            "timeRemaining": "19:23",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 513,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8484801,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 781,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 514,
+            "details": {
+                "xCoord": 65,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 10,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 515,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 401,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 517,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 784,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:28",
+            "timeRemaining": "18:32",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 518,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8484801,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 794,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 519,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "playerId": 8477505,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 785,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:45",
+            "timeRemaining": "18:15",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 520,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 790,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:56",
+            "timeRemaining": "18:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 523,
+            "details": {
+                "xCoord": 21,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8479372,
+                "drawnByPlayerId": 8484227,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:56",
+            "timeRemaining": "18:04",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 525,
+            "details": {
+                "reason": "home-timeout",
+                "secondaryReason": "home-timeout"
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:56",
+            "timeRemaining": "18:04",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 527,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 796,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:20",
+            "timeRemaining": "17:40",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 528,
+            "details": {
+                "xCoord": 58,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8484227,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:28",
+            "timeRemaining": "17:32",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 529,
+            "details": {
+                "xCoord": 57,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 10,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:35",
+            "timeRemaining": "17:25",
+            "situationCode": "1351",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 530,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "slap",
+                "shootingPlayerId": 8482667,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 812,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 535,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 806,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:42",
+            "timeRemaining": "16:18",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 539,
+            "details": {
+                "xCoord": 51,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484801,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 10,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:59",
+            "timeRemaining": "16:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 541,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480043,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 10,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 814,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 544,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "high-sticking-double-minor",
+                "duration": 4,
+                "committedByPlayerId": 8479523,
+                "drawnByPlayerId": 8480009,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 403,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:11",
+            "timeRemaining": "15:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 548,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476624,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 818,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:16",
+            "timeRemaining": "15:44",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": -52,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 819,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:07",
+            "timeRemaining": "14:53",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 550,
+            "details": {
+                "xCoord": -59,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 820,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 551,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 821,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:11",
+            "timeRemaining": "14:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 552,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 835,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:47",
+            "timeRemaining": "13:13",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 566,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 837,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:01",
+            "timeRemaining": "12:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 567,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:09",
+            "timeRemaining": "12:51",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:46",
+            "timeRemaining": "12:14",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 576,
+            "details": {
+                "xCoord": -88,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476905,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 851,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:14",
+            "timeRemaining": "11:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 581,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480043,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 886,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:38",
+            "timeRemaining": "11:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 582,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 24,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8480043,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 887,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:45",
+            "timeRemaining": "11:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 585,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8484801
+            }
+        },
+        {
+            "eventId": 863,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:15",
+            "timeRemaining": "10:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 593,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 864,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:16",
+            "timeRemaining": "10:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 594,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "blockingPlayerId": 8479591,
+                "shootingPlayerId": 8477401,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 595,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 404,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:33",
+            "timeRemaining": "10:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 598,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8477505,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 885,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:09",
+            "timeRemaining": "09:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 599,
+            "details": {
+                "xCoord": -39,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:13",
+            "timeRemaining": "09:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 600,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 405,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:13",
+            "timeRemaining": "09:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 602,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477505,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 871,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:22",
+            "timeRemaining": "09:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 603,
+            "details": {
+                "xCoord": -62,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 455,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:46",
+            "timeRemaining": "09:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 607,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8479393,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 882,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 609,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8480848,
+                "drawnByPlayerId": 8476905,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 878,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 611,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8476905,
+                "drawnByPlayerId": 8480848,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 613,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:01",
+            "timeRemaining": "08:59",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 616,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8483524,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 888,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:38",
+            "timeRemaining": "08:22",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 617,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 905,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:38",
+            "timeRemaining": "07:22",
+            "situationCode": "1441",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 625,
+            "details": {
+                "xCoord": 87,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 28,
+                "playerId": 8477505
+            }
+        },
+        {
+            "eventId": 972,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 632,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8482859,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 503,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 634,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 407,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 636,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8484801,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 906,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 637,
+            "details": {
+                "xCoord": 58,
+                "yCoord": -28,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8482144,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 910,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:44",
+            "timeRemaining": "06:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 641,
+            "details": {
+                "xCoord": 48,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479983,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 928,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:11",
+            "timeRemaining": "05:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 648,
+            "details": {
+                "xCoord": -36,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475768
+            }
+        },
+        {
+            "eventId": 917,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:16",
+            "timeRemaining": "05:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 649,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482859,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 17,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 456,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:39",
+            "timeRemaining": "05:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 654,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8479523,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 930,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:52",
+            "timeRemaining": "05:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 657,
+            "details": {
+                "xCoord": 0,
+                "yCoord": -32,
+                "zoneCode": "N",
+                "playerId": 8483524,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 925,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:57",
+            "timeRemaining": "05:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 658,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 408,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:01",
+            "timeRemaining": "04:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 659,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8471709,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 504,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:03",
+            "timeRemaining": "04:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 660,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 409,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:03",
+            "timeRemaining": "04:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 663,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482859,
+                "winningPlayerId": 8479591,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 931,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:23",
+            "timeRemaining": "04:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 664,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479336,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28,
+                "awaySOG": 17,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 932,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 665,
+            "details": {
+                "xCoord": 38,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8476624,
+                "eventOwnerTeamId": 28,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 985,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:36",
+            "timeRemaining": "04:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": -25,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8481567
+            }
+        },
+        {
+            "eventId": 944,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:38",
+            "timeRemaining": "04:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 667,
+            "details": {
+                "xCoord": 21,
+                "yCoord": 35,
+                "zoneCode": "N",
+                "playerId": 8482859,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 954,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:54",
+            "timeRemaining": "04:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 674,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:25",
+            "timeRemaining": "03:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 677,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 410,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:25",
+            "timeRemaining": "03:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 680,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484801,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 987,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:59",
+            "timeRemaining": "03:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 681,
+            "details": {
+                "xCoord": -70,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8484801
+            }
+        },
+        {
+            "eventId": 988,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 686,
+            "details": {
+                "xCoord": 7,
+                "yCoord": -35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8480848,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 971,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:21",
+            "timeRemaining": "02:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 688,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 956,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:43",
+            "timeRemaining": "02:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 692,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479393,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 959,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:00",
+            "timeRemaining": "02:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 693,
+            "details": {
+                "xCoord": -42,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8484312,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 989,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:29",
+            "timeRemaining": "01:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 703,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 990,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8479336
+            }
+        },
+        {
+            "eventId": 506,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:40",
+            "timeRemaining": "01:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 705,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:40",
+            "timeRemaining": "01:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 707,
+            "details": {
+                "eventOwnerTeamId": 28,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482859,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 973,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:56",
+            "timeRemaining": "01:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 708,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480043,
+                "shootingPlayerId": 8479372,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 991,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:02",
+            "timeRemaining": "00:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 709,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8482859,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 992,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:10",
+            "timeRemaining": "00:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 713,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 23,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 28,
+                "hittingPlayerId": 8476624,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 993,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:13",
+            "timeRemaining": "00:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 714,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8477505
+            }
+        },
+        {
+            "eventId": 994,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:21",
+            "timeRemaining": "00:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 716,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8479983
+            }
+        },
+        {
+            "eventId": 980,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 717,
+            "details": {
+                "xCoord": 24,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "cross-checking",
+                "duration": 2,
+                "committedByPlayerId": 8476624,
+                "drawnByPlayerId": 8476467,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 507,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 719,
+            "details": {
+                "xCoord": 12,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8482667,
+                "drawnByPlayerId": 8480009,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 511,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 721,
+            "details": {
+                "xCoord": 13,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8480009,
+                "drawnByPlayerId": 8482667,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 526,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 723,
+            "details": {
+                "xCoord": 20,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8476467,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 515,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 727,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8482859,
+                "eventOwnerTeamId": 28
+            }
+        },
+        {
+            "eventId": 518,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 729,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8477401,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 732,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480848,
+                "winningPlayerId": 8479591,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 521,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 733
+        },
+        {
+            "eventId": 525,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 737
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 28,
+            "playerId": 8471709,
+            "firstName": {
+                "default": "Marc-Edouard"
+            },
+            "lastName": {
+                "default": "Vlasic"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8471709.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8475726,
+            "firstName": {
+                "default": "Tyler"
+            },
+            "lastName": {
+                "default": "Toffoli"
+            },
+            "sweaterNumber": 73,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8475726.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8476624,
+            "firstName": {
+                "default": "Barclay"
+            },
+            "lastName": {
+                "default": "Goodrow"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8476624.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476905.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8477505,
+            "firstName": {
+                "default": "Alexander"
+            },
+            "lastName": {
+                "default": "Wennberg"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8477505.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8479336,
+            "firstName": {
+                "default": "Carl"
+            },
+            "lastName": {
+                "default": "Grundstrom",
+                "cs": "Grundstr\u00f6m",
+                "fi": "Grundstr\u00f6m",
+                "sk": "Grundstr\u00f6m",
+                "sv": "Grundstr\u00f6m"
+            },
+            "sweaterNumber": 91,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8479336.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479372,
+            "firstName": {
+                "default": "Joshua",
+                "cs": "Josh",
+                "de": "Josh",
+                "es": "Josh",
+                "fi": "Josh",
+                "sk": "Josh",
+                "sv": "Josh"
+            },
+            "lastName": {
+                "default": "Mahura"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479372.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8479393,
+            "firstName": {
+                "default": "Noah"
+            },
+            "lastName": {
+                "default": "Gregor"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8479393.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8479523,
+            "firstName": {
+                "default": "Lucas"
+            },
+            "lastName": {
+                "default": "Carlsson"
+            },
+            "sweaterNumber": 36,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8479523.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8479983,
+            "firstName": {
+                "default": "Mario"
+            },
+            "lastName": {
+                "default": "Ferraro"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8479983.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8480043,
+            "firstName": {
+                "default": "Timothy"
+            },
+            "lastName": {
+                "default": "Liljegren"
+            },
+            "sweaterNumber": 37,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8480043.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8480382,
+            "firstName": {
+                "default": "Alexandar",
+                "fi": "Aleksandar"
+            },
+            "lastName": {
+                "default": "Georgiev",
+                "cs": "Georgijev",
+                "fi": "Georgijev",
+                "sk": "Georgijev"
+            },
+            "sweaterNumber": 40,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8480382.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8480848,
+            "firstName": {
+                "default": "Ty"
+            },
+            "lastName": {
+                "default": "Dellandrea"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8480848.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8481567,
+            "firstName": {
+                "default": "Henry"
+            },
+            "lastName": {
+                "default": "Thrun"
+            },
+            "sweaterNumber": 3,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8481567.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8482144,
+            "firstName": {
+                "default": "Jack"
+            },
+            "lastName": {
+                "default": "Thompson"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8482144.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8482667,
+            "firstName": {
+                "default": "William"
+            },
+            "lastName": {
+                "default": "Eklund"
+            },
+            "sweaterNumber": 72,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8482667.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8482859,
+            "firstName": {
+                "default": "Zack"
+            },
+            "lastName": {
+                "default": "Ostapchuk"
+            },
+            "sweaterNumber": 63,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8482859.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8483481,
+            "firstName": {
+                "default": "Cam"
+            },
+            "lastName": {
+                "default": "Lund"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8483481.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8484227,
+            "firstName": {
+                "default": "Will"
+            },
+            "lastName": {
+                "default": "Smith"
+            },
+            "sweaterNumber": 2,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8484227.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8484312,
+            "firstName": {
+                "default": "Georgi"
+            },
+            "lastName": {
+                "default": "Romanov"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8484312.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8484801,
+            "firstName": {
+                "default": "Macklin"
+            },
+            "lastName": {
+                "default": "Celebrini"
+            },
+            "sweaterNumber": 71,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8484801.png"
+        },
+        {
+            "teamId": 28,
+            "playerId": 8484911,
+            "firstName": {
+                "default": "Collin"
+            },
+            "lastName": {
+                "default": "Graf"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SJS/8484911.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -94,3 +94,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #74: Dallas Stars vs Seattle Kraken - Seattle loses 5-1](./2024-25/regular-season/20250329-DAL-vs-SEA-2024021169.json)
 - [GAME #75: Dallas Stars vs Seattle Kraken - Seattle loses 3-1](./2024-25/regular-season/20250331-DAL-vs-SEA-2024021181.json)
 - [GAME #76: Seattle Kraken vs Vancouver Canucks - Seattle wins 5-0](./2024-25/regular-season/20250402-SEA-vs-VAN-2024021196.json)
+- [GAME #77: Seattle Kraken vs San Jose Sharks - Seattle wins 5-1](./2024-25/regular-season/20250405-SEA-vs-SJS-2024021221.json)


### PR DESCRIPTION
# Description

This PR adds the data for the Seattle Kraken's game #77 against the San Jose Sharks from April 5, 2025.

Changes:
- Added game data file for the April 5, 2025 game against the San Jose Sharks
- Updated the NHL README.md to include the new game
- Seattle won 5-1 against San Jose in this game

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] All existing tests pass
