### PR TITLE
chore: Add St. Louis Blues vs Seattle Kraken game from April 12, 2025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1781,6 +1781,7 @@
     "Smyth",
     "Smythe",
     "Sneed",
+    "Snuggerud",
     "Soderblom",
     "Solovyov",
     "Sopiarz",

--- a/data/NHL - National Hockey League/2024-25/regular-season/20250412-STL-vs-SEA-2024021275.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250412-STL-vs-SEA-2024021275.json
@@ -1,0 +1,7682 @@
+{
+    "id": 2024021275,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-04-12",
+    "venue": {
+        "default": "Climate Pledge Arena"
+    },
+    "venueLocation": {
+        "default": "Seattle"
+    },
+    "startTimeUTC": "2025-04-13T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 566,
+            "market": "A",
+            "countryCode": "US",
+            "network": "FDSNMW",
+            "sequenceNumber": 273
+        },
+        {
+            "id": 554,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 388,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "OFF",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 5,
+        "periodType": "SO",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 19,
+        "commonName": {
+            "default": "Blues"
+        },
+        "abbrev": "STL",
+        "score": 3,
+        "sog": 23,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/STL_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/STL_dark.svg",
+        "placeName": {
+            "default": "St. Louis"
+        },
+        "placeNameWithPreposition": {
+            "default": "St. Louis",
+            "fr": "de St. Louis"
+        }
+    },
+    "homeTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 4,
+        "sog": 17,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "SO"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 10
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8476897,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:07",
+            "timeRemaining": "19:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 20,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482737,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 84,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476457
+            }
+        },
+        {
+            "eventId": 97,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:49",
+            "timeRemaining": "18:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 34,
+            "details": {
+                "xCoord": 31,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 102,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:52",
+            "timeRemaining": "18:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 35,
+            "details": {
+                "xCoord": 51,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8482089
+            }
+        },
+        {
+            "eventId": 83,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:27",
+            "timeRemaining": "17:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 45,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8483524,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 351,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 46,
+            "details": {
+                "xCoord": 91,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "reason": "failed-bank-attempt",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 85,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 47,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477573,
+                "shootingPlayerId": 8481789,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 112,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:37",
+            "timeRemaining": "17:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 48,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8480281
+            }
+        },
+        {
+            "eventId": 116,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:39",
+            "timeRemaining": "17:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 49,
+            "details": {
+                "xCoord": -1,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8476889,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 103,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:43",
+            "timeRemaining": "17:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 50,
+            "details": {
+                "xCoord": 14,
+                "yCoord": -2,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:04",
+            "timeRemaining": "16:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 58,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 108,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 59,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 66,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 68,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8475170,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 132,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:48",
+            "timeRemaining": "16:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 69,
+            "details": {
+                "xCoord": -99,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "playerId": 8483516,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 146,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "16:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 70,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:59",
+            "timeRemaining": "16:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 71,
+            "details": {
+                "xCoord": -40,
+                "yCoord": 23,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8480009
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:02",
+            "timeRemaining": "15:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 72,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:02",
+            "timeRemaining": "15:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 75,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476897,
+                "winningPlayerId": 8482751,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 211,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:15",
+            "timeRemaining": "15:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8478472,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 210,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:21",
+            "timeRemaining": "15:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 77,
+            "details": {
+                "xCoord": 45,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477955
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:29",
+            "timeRemaining": "15:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 78,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:29",
+            "timeRemaining": "15:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 81,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 216,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:45",
+            "timeRemaining": "15:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 85,
+            "details": {
+                "xCoord": -12,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "playerId": 8477402
+            }
+        },
+        {
+            "eventId": 229,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 86,
+            "details": {
+                "xCoord": -60,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 19,
+                "playerId": 8480023
+            }
+        },
+        {
+            "eventId": 121,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:08",
+            "timeRemaining": "14:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 92,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477573,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 235,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:37",
+            "timeRemaining": "14:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 96,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 19,
+                "playerId": 8481006
+            }
+        },
+        {
+            "eventId": 134,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 104,
+            "details": {
+                "xCoord": -40,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475764,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 1,
+                "homeSOG": 0
+            }
+        },
+        {
+            "eventId": 135,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:30",
+            "timeRemaining": "13:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 105,
+            "details": {
+                "xCoord": -45,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8476892,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 221,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 113,
+            "details": {
+                "xCoord": 4,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8476897
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:23",
+            "timeRemaining": "12:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 116,
+            "details": {
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 206,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:56",
+            "timeRemaining": "12:04",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 127,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481006,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 213,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 128,
+            "details": {
+                "xCoord": -19,
+                "yCoord": -34,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8478472,
+                "drawnByPlayerId": 8481554,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 130,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 133,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 217,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:00",
+            "timeRemaining": "12:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 134,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 218,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:21",
+            "timeRemaining": "11:39",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 135,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:23",
+            "timeRemaining": "11:37",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 136,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:23",
+            "timeRemaining": "11:37",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 138,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476889,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 234,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 150,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 240,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:59",
+            "timeRemaining": "10:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 155,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 242,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 157,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 253,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:20",
+            "timeRemaining": "08:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 167,
+            "details": {
+                "xCoord": -52,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8482089,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:22",
+            "timeRemaining": "08:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 168,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:22",
+            "timeRemaining": "08:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 171,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8475170,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:24",
+            "timeRemaining": "08:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 172,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8482089,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 258,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:33",
+            "timeRemaining": "08:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 173,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 259,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:40",
+            "timeRemaining": "08:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 174,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475170,
+                "shootingPlayerId": 8479372,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 288,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:45",
+            "timeRemaining": "08:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 175,
+            "details": {
+                "xCoord": 92,
+                "yCoord": 26,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8476892,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 280,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:35",
+            "timeRemaining": "07:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 185,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477955
+            }
+        },
+        {
+            "eventId": 287,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:47",
+            "timeRemaining": "07:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 186,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "playerId": 8482858,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 274,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:58",
+            "timeRemaining": "07:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 193,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8482737,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 194,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 197,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476889,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 281,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:08",
+            "timeRemaining": "06:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 198,
+            "details": {
+                "xCoord": 29,
+                "yCoord": -35,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 282,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:26",
+            "timeRemaining": "06:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 199,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 26,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:28",
+            "timeRemaining": "06:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 200,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:28",
+            "timeRemaining": "06:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 203,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8475170,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 209,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 294,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 210,
+            "details": {
+                "xCoord": -43,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482751,
+                "shootingPlayerId": 8475753,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 297,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:26",
+            "timeRemaining": "05:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 213,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 413,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 218,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:04",
+            "timeRemaining": "04:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 219,
+            "details": {
+                "xCoord": -32,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475764,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 2,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 403,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:11",
+            "timeRemaining": "04:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 220,
+            "details": {
+                "xCoord": 44,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:15",
+            "timeRemaining": "04:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 222,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:15",
+            "timeRemaining": "04:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 225,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477402,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 154,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:16",
+            "timeRemaining": "04:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 226,
+            "details": {
+                "xCoord": 36,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 409,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:47",
+            "timeRemaining": "04:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 227,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476892,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:57",
+            "timeRemaining": "04:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 230,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 3,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 425,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 236,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 31,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8480281,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 443,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:41",
+            "timeRemaining": "03:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 237,
+            "details": {
+                "xCoord": 10,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8481006,
+                "hitteePlayerId": 8477955
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:51",
+            "timeRemaining": "03:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 240,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:51",
+            "timeRemaining": "03:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 243,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8483524,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 424,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:18",
+            "timeRemaining": "02:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 244,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475753,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 458,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:35",
+            "timeRemaining": "02:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 248,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8475753
+            }
+        },
+        {
+            "eventId": 457,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:00",
+            "timeRemaining": "02:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 254,
+            "details": {
+                "xCoord": -14,
+                "yCoord": 13,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477986
+            }
+        },
+        {
+            "eventId": 459,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:39",
+            "timeRemaining": "01:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 264,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 10,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8480009
+            }
+        },
+        {
+            "eventId": 454,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:42",
+            "timeRemaining": "00:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 275,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 460,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:53",
+            "timeRemaining": "00:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 277,
+            "details": {
+                "xCoord": -5,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 278
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 285
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 286,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476889,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 474,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:05",
+            "timeRemaining": "19:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 287,
+            "details": {
+                "xCoord": 26,
+                "yCoord": 37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8480281,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 468,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:10",
+            "timeRemaining": "19:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 288,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "playerId": 8476905,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 463,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 289,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480281,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 4,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:26",
+            "timeRemaining": "19:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 290,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:26",
+            "timeRemaining": "19:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 293,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475170,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 467,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:27",
+            "timeRemaining": "19:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 294,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8483516,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 485,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 295,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477444
+            }
+        },
+        {
+            "eventId": 469,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:35",
+            "timeRemaining": "19:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 296,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475170,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 5,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 470,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:37",
+            "timeRemaining": "19:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 297,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475170,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 6,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:38",
+            "timeRemaining": "19:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 298,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:38",
+            "timeRemaining": "19:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 301,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 475,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:48",
+            "timeRemaining": "19:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 302,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 495,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 303,
+            "details": {
+                "xCoord": 99,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 19,
+                "playerId": 8477402
+            }
+        },
+        {
+            "eventId": 486,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:52",
+            "timeRemaining": "18:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 313,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "blockingPlayerId": 8470600,
+                "shootingPlayerId": 8477955,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 487,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:03",
+            "timeRemaining": "17:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 314,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475170,
+                "shootingPlayerId": 8482751,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 489,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:18",
+            "timeRemaining": "17:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 316,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 352,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "17:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 323,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 497,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:48",
+            "timeRemaining": "17:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 324,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 332,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 335,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476889,
+                "winningPlayerId": 8476905,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 508,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:35",
+            "timeRemaining": "16:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 336,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475753,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 7,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 509,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:44",
+            "timeRemaining": "16:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 337,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 25,
+                "assist1PlayerId": 8474586,
+                "assist1PlayerTotal": 16,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-schwartz-scores-goal-against-jordan-binnington-6371426048112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-schwartz-marque-un-but-contre-jordan-binnington-6371425262112",
+                "highlightClip": 6371426048112,
+                "highlightClipFr": 6371425262112,
+                "discreteClip": 6371423994112,
+                "discreteClipFr": 6371423094112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev509.json"
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:44",
+            "timeRemaining": "16:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 340,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 513,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:03",
+            "timeRemaining": "15:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 341,
+            "details": {
+                "xCoord": 46,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476892,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 8,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 542,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:55",
+            "timeRemaining": "15:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 352,
+            "details": {
+                "xCoord": 35,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8483516
+            }
+        },
+        {
+            "eventId": 549,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -9,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 530,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:00",
+            "timeRemaining": "15:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:05",
+            "timeRemaining": "14:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 355,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:05",
+            "timeRemaining": "14:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 357,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8475170,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 560,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:23",
+            "timeRemaining": "14:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": -1,
+                "yCoord": -35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8483516,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 528,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:34",
+            "timeRemaining": "14:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 361,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8483516,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 363,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 366,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:50",
+            "timeRemaining": "14:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 367,
+            "details": {
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 537,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:56",
+            "timeRemaining": "14:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 368,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8479385,
+                "drawnByPlayerId": 8477444,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:56",
+            "timeRemaining": "14:04",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 372,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8475768,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 543,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:41",
+            "timeRemaining": "13:19",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 373,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:05",
+            "timeRemaining": "12:55",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 382,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476897,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 9,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 602,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:26",
+            "timeRemaining": "11:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 391,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 10,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:27",
+            "timeRemaining": "11:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 392,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:27",
+            "timeRemaining": "11:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 395,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 574,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:45",
+            "timeRemaining": "11:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 396,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479372
+            }
+        },
+        {
+            "eventId": 588,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:06",
+            "timeRemaining": "10:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 399,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "playerId": 8477402,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 572,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:27",
+            "timeRemaining": "10:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 404,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "blockingPlayerId": 8479385,
+                "shootingPlayerId": 8480023,
+                "eventOwnerTeamId": 19,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 582,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 412,
+            "details": {
+                "xCoord": -42,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 603,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 414,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "bat",
+                "shootingPlayerId": 8477573,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 663,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:35",
+            "timeRemaining": "09:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": -5,
+                "yCoord": 35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8470600
+            }
+        },
+        {
+            "eventId": 665,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:48",
+            "timeRemaining": "09:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 420,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8476889
+            }
+        },
+        {
+            "eventId": 604,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:54",
+            "timeRemaining": "09:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 422,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "failed-bank-attempt",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8476889,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 667,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:57",
+            "timeRemaining": "09:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 423,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8476889
+            }
+        },
+        {
+            "eventId": 651,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:05",
+            "timeRemaining": "07:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 435,
+            "details": {
+                "xCoord": 60,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482089,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:51",
+            "timeRemaining": "07:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 446,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 306,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:51",
+            "timeRemaining": "07:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 449,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480023,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 668,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:09",
+            "timeRemaining": "06:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 450,
+            "details": {
+                "xCoord": 59,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8475753,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 353,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 451,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 307,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 452,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 697,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:32",
+            "timeRemaining": "06:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 453,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 23,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8477402,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 677,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:57",
+            "timeRemaining": "06:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 462,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:59",
+            "timeRemaining": "06:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 463,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:59",
+            "timeRemaining": "06:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 466,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476889,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 310,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:04",
+            "timeRemaining": "05:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 467,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:04",
+            "timeRemaining": "05:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 468,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476889,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 699,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:17",
+            "timeRemaining": "05:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 469,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8477573,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:31",
+            "timeRemaining": "05:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 470,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -8,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8480281,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 704,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:33",
+            "timeRemaining": "05:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 471,
+            "details": {
+                "xCoord": 41,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8481006,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 691,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 472,
+            "details": {
+                "xCoord": 33,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "playerId": 8476889,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 708,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:37",
+            "timeRemaining": "05:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 473,
+            "details": {
+                "xCoord": 25,
+                "yCoord": 35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8476889
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:02",
+            "timeRemaining": "04:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 478,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 694,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 481,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 4,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "holding-the-stick",
+                "duration": 2,
+                "committedByPlayerId": 8482858,
+                "drawnByPlayerId": 8476897,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 314,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 483,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 315,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 486,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480023,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 698,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:48",
+            "timeRemaining": "04:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 487,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482737,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 11,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 316,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:50",
+            "timeRemaining": "04:10",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 488,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 317,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:50",
+            "timeRemaining": "04:10",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 490,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 705,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:29",
+            "timeRemaining": "03:31",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 491,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "bat",
+                "shootingPlayerId": 8483516,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 707,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:45",
+            "timeRemaining": "03:15",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 492,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482737,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 12,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 709,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:14",
+            "timeRemaining": "02:46",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 493,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483516,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 318,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:16",
+            "timeRemaining": "02:44",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 494,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 319,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:16",
+            "timeRemaining": "02:44",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 497,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8475170,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 713,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 498,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8479385,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 739,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:57",
+            "timeRemaining": "02:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 502,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8482089
+            }
+        },
+        {
+            "eventId": 320,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:16",
+            "timeRemaining": "01:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 506,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 321,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:16",
+            "timeRemaining": "01:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 508,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476897,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 155,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 511,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 322,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 526
+        },
+        {
+            "eventId": 328,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 533
+        },
+        {
+            "eventId": 327,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 534,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480023,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 329,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:08",
+            "timeRemaining": "19:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 535,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 330,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:08",
+            "timeRemaining": "19:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 536,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 743,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:14",
+            "timeRemaining": "19:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 537,
+            "details": {
+                "xCoord": -47,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 13,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 331,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:16",
+            "timeRemaining": "19:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 538,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 332,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:16",
+            "timeRemaining": "19:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 539,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480023,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 333,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:28",
+            "timeRemaining": "19:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 541,
+            "details": {
+                "reason": "referee-or-linesman",
+                "secondaryReason": "player-injury"
+            }
+        },
+        {
+            "eventId": 334,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:28",
+            "timeRemaining": "19:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 542,
+            "details": {
+                "reason": "rink-repair",
+                "secondaryReason": "rink-repair"
+            }
+        },
+        {
+            "eventId": 335,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:28",
+            "timeRemaining": "19:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 545,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476889,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 753,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:34",
+            "timeRemaining": "19:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 546,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8480281
+            }
+        },
+        {
+            "eventId": 756,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:48",
+            "timeRemaining": "19:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -27,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476467,
+                "hitteePlayerId": 8476889
+            }
+        },
+        {
+            "eventId": 749,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:56",
+            "timeRemaining": "19:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475753,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 14,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 750,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:02",
+            "timeRemaining": "18:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477573,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 751,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:06",
+            "timeRemaining": "18:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 550,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8476889,
+                "scoringPlayerTotal": 5,
+                "assist1PlayerId": 8477573,
+                "assist1PlayerTotal": 8,
+                "assist2PlayerId": 8475181,
+                "assist2PlayerTotal": 3,
+                "eventOwnerTeamId": 19,
+                "goalieInNetId": 8475831,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-faksa-scores-goal-against-philipp-grubauer-6371426560112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-faksa-marque-un-but-contre-philipp-grubauer-6371425116112",
+                "highlightClip": 6371426560112,
+                "highlightClipFr": 6371425116112,
+                "discreteClip": 6371425491112,
+                "discreteClipFr": 6371426460112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev751.json"
+        },
+        {
+            "eventId": 336,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:06",
+            "timeRemaining": "18:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 553,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:40",
+            "timeRemaining": "18:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 555,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483516,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:51",
+            "timeRemaining": "18:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 556,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 339,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:51",
+            "timeRemaining": "18:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 559,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476889,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 765,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:02",
+            "timeRemaining": "17:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 561,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482737,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 15,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 782,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:26",
+            "timeRemaining": "17:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 562,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8476897
+            }
+        },
+        {
+            "eventId": 784,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 572,
+            "details": {
+                "xCoord": -38,
+                "yCoord": -35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 19,
+                "playerId": 8475181
+            }
+        },
+        {
+            "eventId": 787,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:26",
+            "timeRemaining": "16:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 573,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 340,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 578,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 341,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 581,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476889,
+                "winningPlayerId": 8477955,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 342,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:49",
+            "timeRemaining": "16:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 582,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 343,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:49",
+            "timeRemaining": "16:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 583,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476889,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 786,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:03",
+            "timeRemaining": "15:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 584,
+            "details": {
+                "xCoord": -71,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477573,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 16,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 901,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:05",
+            "timeRemaining": "15:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 585,
+            "details": {
+                "xCoord": -74,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8477573,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 344,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 588,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 345,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 591,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8475170,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 346,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:54",
+            "timeRemaining": "15:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 592,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 347,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:54",
+            "timeRemaining": "15:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 593,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 795,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:57",
+            "timeRemaining": "15:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 594,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8475181,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 854,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:06",
+            "timeRemaining": "14:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 595,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8475181
+            }
+        },
+        {
+            "eventId": 858,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:14",
+            "timeRemaining": "14:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "playerId": 8482665,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 866,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 601,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8480009
+            }
+        },
+        {
+            "eventId": 851,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 603,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8478472,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 608,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:57",
+            "timeRemaining": "14:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 604,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -23,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475753,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 856,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:10",
+            "timeRemaining": "13:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 606,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -10,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8478472,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 348,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 607,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 349,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:19",
+            "timeRemaining": "13:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 610,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476889,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 862,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:29",
+            "timeRemaining": "13:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 611,
+            "details": {
+                "xCoord": -95,
+                "yCoord": 20,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8480281,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 859,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:42",
+            "timeRemaining": "13:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 612,
+            "details": {
+                "xCoord": 50,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:44",
+            "timeRemaining": "13:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 613,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8479591,
+                "scoringPlayerTotal": 9,
+                "assist1PlayerId": 8481789,
+                "assist1PlayerTotal": 6,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 1,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-eyssimont-scores-goal-against-jordan-binnington-6371426108112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-eyssimont-marque-un-but-contre-jordan-binnington-6371424712112",
+                "highlightClip": 6371426108112,
+                "highlightClipFr": 6371424712112,
+                "discreteClip": 6371426109112,
+                "discreteClipFr": 6371427262112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev860.json"
+        },
+        {
+            "eventId": 350,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:44",
+            "timeRemaining": "13:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 616,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480023,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 895,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:53",
+            "timeRemaining": "13:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 617,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 865,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:53",
+            "timeRemaining": "13:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 618,
+            "details": {
+                "xCoord": -74,
+                "yCoord": 42,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 17,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 867,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:10",
+            "timeRemaining": "12:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476892,
+                "shootingPlayerId": 8474586,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 868,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:21",
+            "timeRemaining": "12:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 620,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8476892,
+                "scoringPlayerTotal": 16,
+                "assist1PlayerId": 8480023,
+                "assist1PlayerTotal": 58,
+                "assist2PlayerId": 8479385,
+                "assist2PlayerTotal": 34,
+                "eventOwnerTeamId": 19,
+                "goalieInNetId": 8475831,
+                "awayScore": 2,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-parayko-scores-goal-against-philipp-grubauer-6371427950112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-parayko-marque-un-but-contre-philipp-grubauer-6371426116112",
+                "highlightClip": 6371427950112,
+                "highlightClipFr": 6371426116112,
+                "discreteClip": 6371426671112,
+                "discreteClipFr": 6371425891112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev868.json"
+        },
+        {
+            "eventId": 801,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:21",
+            "timeRemaining": "12:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 623,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476897,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 872,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:34",
+            "timeRemaining": "12:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 624,
+            "details": {
+                "xCoord": -45,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "scoringPlayerId": 8475181,
+                "scoringPlayerTotal": 2,
+                "assist1PlayerId": 8482737,
+                "assist1PlayerTotal": 16,
+                "assist2PlayerId": 8478472,
+                "assist2PlayerTotal": 10,
+                "eventOwnerTeamId": 19,
+                "goalieInNetId": 8475831,
+                "awayScore": 3,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-leddy-scores-goal-against-philipp-grubauer-6371426178112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-leddy-marque-un-but-contre-philipp-grubauer-6371425991112",
+                "highlightClip": 6371426178112,
+                "highlightClipFr": 6371425991112,
+                "discreteClip": 6371425303112,
+                "discreteClipFr": 6371425406112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev872.json"
+        },
+        {
+            "eventId": 802,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:34",
+            "timeRemaining": "12:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 627,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8475170,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 951,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:41",
+            "timeRemaining": "12:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 628,
+            "details": {
+                "xCoord": -99,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8475831
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:44",
+            "timeRemaining": "12:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 629,
+            "details": {
+                "xCoord": -93,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 19,
+                "playerId": 8475170
+            }
+        },
+        {
+            "eventId": 876,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:53",
+            "timeRemaining": "12:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 630,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475170,
+                "shootingPlayerId": 8477444,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 883,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:42",
+            "timeRemaining": "11:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 636,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 18,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 803,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:45",
+            "timeRemaining": "11:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 637,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 804,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:45",
+            "timeRemaining": "11:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 639,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 886,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:05",
+            "timeRemaining": "10:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 640,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476892,
+                "shootingPlayerId": 8475768,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 953,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:34",
+            "timeRemaining": "10:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 649,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 10,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8475753,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 897,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 651,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "scoringPlayerId": 8483524,
+                "scoringPlayerTotal": 19,
+                "assist1PlayerId": 8476467,
+                "assist1PlayerTotal": 12,
+                "assist2PlayerId": 8481789,
+                "assist2PlayerTotal": 7,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 3,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/stl-sea-wright-scores-goal-against-jordan-binnington-6371425493112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/stl-sea-wright-marque-un-but-contre-jordan-binnington-6371426469112",
+                "highlightClip": 6371425493112,
+                "highlightClipFr": 6371426469112,
+                "discreteClip": 6371425783112,
+                "discreteClipFr": 6371427171112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021275/ev897.json"
+        },
+        {
+            "eventId": 806,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 653,
+            "details": {
+                "reason": "referee-or-linesman",
+                "secondaryReason": "video-review"
+            }
+        },
+        {
+            "eventId": 807,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 654,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476897,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 962,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 655,
+            "details": {
+                "xCoord": -1,
+                "yCoord": 20,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 967,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:27",
+            "timeRemaining": "09:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 660,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -11,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8476892,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 966,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:34",
+            "timeRemaining": "09:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 661,
+            "details": {
+                "xCoord": 92,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479591
+            }
+        },
+        {
+            "eventId": 971,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:42",
+            "timeRemaining": "09:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": 1,
+                "yCoord": -21,
+                "zoneCode": "N",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:49",
+            "timeRemaining": "09:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 667,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 964,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:04",
+            "timeRemaining": "08:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 668,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476892,
+                "shootingPlayerId": 8477955,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:11",
+            "timeRemaining": "08:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 669,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 809,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:11",
+            "timeRemaining": "08:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 671,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 986,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:33",
+            "timeRemaining": "08:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 675,
+            "details": {
+                "xCoord": -89,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8479385
+            }
+        },
+        {
+            "eventId": 994,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:55",
+            "timeRemaining": "08:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 678,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 1,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 990,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:06",
+            "timeRemaining": "07:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 685,
+            "details": {
+                "xCoord": 18,
+                "yCoord": -35,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "playerId": 8475181
+            }
+        },
+        {
+            "eventId": 982,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:11",
+            "timeRemaining": "07:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 687,
+            "details": {
+                "xCoord": 71,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 997,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:45",
+            "timeRemaining": "07:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482737,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 989,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:56",
+            "timeRemaining": "07:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 694,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 696,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 811,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 699,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480023,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 998,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:19",
+            "timeRemaining": "06:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 700,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8480023,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1000,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:48",
+            "timeRemaining": "06:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 703,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476892,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1011,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 711,
+            "details": {
+                "xCoord": -9,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 1009,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:23",
+            "timeRemaining": "05:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 712,
+            "details": {
+                "xCoord": -53,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483516,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 19,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 812,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:26",
+            "timeRemaining": "05:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 713,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 813,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:26",
+            "timeRemaining": "05:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 716,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8475170,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1014,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:27",
+            "timeRemaining": "05:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 717,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8474586,
+                "shootingPlayerId": 8483516,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1015,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:41",
+            "timeRemaining": "05:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 718,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8475764,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1016,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:57",
+            "timeRemaining": "05:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 719,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8475764,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1027,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 727,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8478472,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 1038,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:22",
+            "timeRemaining": "04:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 728,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8475753,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 814,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 729,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 815,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 732,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476889,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1028,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:43",
+            "timeRemaining": "04:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 733,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475753,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 20,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 1056,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:51",
+            "timeRemaining": "04:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 734,
+            "details": {
+                "xCoord": -1,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479591,
+                "hitteePlayerId": 8476889
+            }
+        },
+        {
+            "eventId": 1058,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 739,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8475181
+            }
+        },
+        {
+            "eventId": 1071,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:21",
+            "timeRemaining": "03:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 744,
+            "details": {
+                "xCoord": 9,
+                "yCoord": 32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "hittingPlayerId": 8482089,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 1077,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:42",
+            "timeRemaining": "03:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 746,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 25,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8481006
+            }
+        },
+        {
+            "eventId": 1057,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:44",
+            "timeRemaining": "02:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 757,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "playerId": 8478407,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1069,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:01",
+            "timeRemaining": "01:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 762,
+            "details": {
+                "xCoord": -25,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "playerId": 8482737,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 816,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 763,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:11",
+            "timeRemaining": "01:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 765,
+            "details": {
+                "eventOwnerTeamId": 19,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480023,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1060,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:28",
+            "timeRemaining": "01:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 767,
+            "details": {
+                "xCoord": -55,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480023,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 1082,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:34",
+            "timeRemaining": "01:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 769,
+            "details": {
+                "xCoord": 21,
+                "yCoord": 42,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 19,
+                "playerId": 8475753
+            }
+        },
+        {
+            "eventId": 1072,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:02",
+            "timeRemaining": "00:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 777,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475170,
+                "shootingPlayerId": 8477986,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1073,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:03",
+            "timeRemaining": "00:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 778,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475181,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 818,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:22",
+            "timeRemaining": "00:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 779,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 819,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:22",
+            "timeRemaining": "00:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 782,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480023,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1078,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:31",
+            "timeRemaining": "00:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 783,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -30,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480023,
+                "shootingPlayerId": 8477444,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1079,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:53",
+            "timeRemaining": "00:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 784,
+            "details": {
+                "xCoord": 28,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 1080,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:55",
+            "timeRemaining": "00:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 785,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 820,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 786
+        },
+        {
+            "eventId": 826,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 791
+        },
+        {
+            "eventId": 825,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 794,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8475170,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1094,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:11",
+            "timeRemaining": "02:49",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 804,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8483516,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1104,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:18",
+            "timeRemaining": "01:42",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 814,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 1106,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:33",
+            "timeRemaining": "01:27",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 817,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481554,
+                "shootingPlayerId": 8475170,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1108,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:40",
+            "timeRemaining": "01:20",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 819,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477444,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 1113,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:07",
+            "timeRemaining": "00:53",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 824,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8477402,
+                "eventOwnerTeamId": 19,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 827,
+            "periodDescriptor": {
+                "number": 4,
+                "periodType": "OT",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1331",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 829
+        },
+        {
+            "eventId": 832,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 834
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 837,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 3,
+                "homeScore": 3
+            }
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 838,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8482089,
+                "eventOwnerTeamId": 19,
+                "goalieInNetId": 8475831,
+                "awayScore": 3,
+                "homeScore": 3
+            }
+        },
+        {
+            "eventId": 835,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 839,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 836,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 840,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8480023,
+                "eventOwnerTeamId": 19,
+                "goalieInNetId": 8475831,
+                "awayScore": 3,
+                "homeScore": 3
+            }
+        },
+        {
+            "eventId": 837,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 841,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 3,
+                "homeScore": 3
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 842,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475170,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 839,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 843,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 840,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 844,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482737,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 21,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 841,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 845,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 21,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 842,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 846,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477402,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19,
+                "awaySOG": 22,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 843,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 847,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8476412,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 22,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 844,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 848,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479385,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 845,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 849,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8476905,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8476412,
+                "awayScore": 3,
+                "homeScore": 3,
+                "discreteClip": 6371428171112,
+                "discreteClipFr": 6371426802112
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 850,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483516,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 19
+            }
+        },
+        {
+            "eventId": 847,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 523,
+            "typeDescKey": "shootout-complete",
+            "sortOrder": 851
+        },
+        {
+            "eventId": 848,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 852
+        },
+        {
+            "eventId": 1152,
+            "periodDescriptor": {
+                "number": 5,
+                "periodType": "SO",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 856
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 19,
+            "playerId": 8470600,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Suter"
+            },
+            "sweaterNumber": 22,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8470600.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8475170,
+            "firstName": {
+                "default": "Brayden"
+            },
+            "lastName": {
+                "default": "Schenn"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8475170.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8475181,
+            "firstName": {
+                "default": "Nick"
+            },
+            "lastName": {
+                "default": "Leddy"
+            },
+            "sweaterNumber": 4,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8475181.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8475753,
+            "firstName": {
+                "default": "Justin"
+            },
+            "lastName": {
+                "default": "Faulk"
+            },
+            "sweaterNumber": 72,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8475753.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8475764,
+            "firstName": {
+                "default": "Cam"
+            },
+            "lastName": {
+                "default": "Fowler"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8475764.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8476412,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Binnington"
+            },
+            "sweaterNumber": 50,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8476412.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8476889,
+            "firstName": {
+                "default": "Radek"
+            },
+            "lastName": {
+                "default": "Faksa"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8476889.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8476892,
+            "firstName": {
+                "default": "Colton"
+            },
+            "lastName": {
+                "default": "Parayko"
+            },
+            "sweaterNumber": 55,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8476892.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8476897,
+            "firstName": {
+                "default": "Oskar"
+            },
+            "lastName": {
+                "default": "Sundqvist"
+            },
+            "sweaterNumber": 70,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8476897.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476905.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8477402,
+            "firstName": {
+                "default": "Pavel"
+            },
+            "lastName": {
+                "default": "Buchnevich",
+                "cs": "Bu\u010dn\u011bvi\u010d",
+                "fi": "Butshnevitsh",
+                "sk": "Bu\u010dn\u011bvi\u010d"
+            },
+            "sweaterNumber": 89,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8477402.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8477573,
+            "firstName": {
+                "default": "Nathan"
+            },
+            "lastName": {
+                "default": "Walker"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8477573.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8478472,
+            "firstName": {
+                "default": "Mathieu"
+            },
+            "lastName": {
+                "default": "Joseph"
+            },
+            "sweaterNumber": 71,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8478472.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479372,
+            "firstName": {
+                "default": "Joshua",
+                "cs": "Josh",
+                "de": "Josh",
+                "es": "Josh",
+                "fi": "Josh",
+                "sk": "Josh",
+                "sv": "Josh"
+            },
+            "lastName": {
+                "default": "Mahura"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479372.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8479385,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Kyrou"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8479385.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8480023,
+            "firstName": {
+                "default": "Robert"
+            },
+            "lastName": {
+                "default": "Thomas"
+            },
+            "sweaterNumber": 18,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8480023.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8480281,
+            "firstName": {
+                "default": "Alexey",
+                "cs": "Alexej",
+                "de": "Alexei",
+                "es": "Alexei",
+                "fi": "Aleksei",
+                "sk": "Alexej",
+                "sv": "Alexei"
+            },
+            "lastName": {
+                "default": "Toropchenko",
+                "cs": "Torop\u010denko",
+                "fi": "Toroptshenko",
+                "sk": "Torop\u010denko"
+            },
+            "sweaterNumber": 13,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8480281.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8480981,
+            "firstName": {
+                "default": "Joel"
+            },
+            "lastName": {
+                "default": "Hofer"
+            },
+            "sweaterNumber": 30,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8480981.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8481006,
+            "firstName": {
+                "default": "Tyler"
+            },
+            "lastName": {
+                "default": "Tucker"
+            },
+            "sweaterNumber": 75,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8481006.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8482089,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "Neighbours"
+            },
+            "sweaterNumber": 63,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8482089.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8482737,
+            "firstName": {
+                "default": "Zack"
+            },
+            "lastName": {
+                "default": "Bolduc"
+            },
+            "sweaterNumber": 76,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8482737.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482751,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Winterton"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482751.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 19,
+            "playerId": 8483516,
+            "firstName": {
+                "default": "Jimmy"
+            },
+            "lastName": {
+                "default": "Snuggerud"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/STL/8483516.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -98,3 +98,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #78: Seattle Kraken vs Los Angeles Kings - Seattle wins 2-1](./2024-25/regular-season/20250407-SEA-vs-LAK-2024021233.json)
 - [GAME #79: Seattle Kraken vs Utah Hockey Club - Seattle loses 7-1](./2024-25/regular-season/20250408-SEA-vs-UTA-2024021243.json)
 - [GAME #80: Seattle Kraken vs Vegas Golden Knights - Seattle loses 2-1](./2024-25/regular-season/20250410-SEA-vs-VGK-2024021258.json)
+- [GAME #81: St. Louis Blues vs Seattle Kraken - Seattle wins 4-3 in SO](./2024-25/regular-season/20250412-STL-vs-SEA-2024021275.json)


### PR DESCRIPTION
# Description

This PR adds the April 12th, 2025 St. Louis Blues vs Seattle Kraken game data to the project. The Kraken won 4-3 in a shootout.

- Downloaded game data (20250412-STL-vs-SEA-2024021275.json)
- Updated NHL README.md to include Game #81

## Type of Change

version: chore    # General maintenance

## Testing

- [x] All existing tests pass
- [x] My commits are signed with GPG
