### PR TITLE
chore: Add Kraken vs Kings game from 2025-04-15

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "Aime",
     "Aiyuk",
     "Akers",
+    "Akil",
     "Akins",
     "Akira",
     "Akito",

--- a/data/NHL - National Hockey League/2024-25/regular-season/20250415-LAK-vs-SEA-2024021300.json
+++ b/data/NHL - National Hockey League/2024-25/regular-season/20250415-LAK-vs-SEA-2024021300.json
@@ -1,0 +1,7687 @@
+{
+    "id": 2024021300,
+    "season": 20242025,
+    "gameType": 2,
+    "limitedScoring": false,
+    "gameDate": "2025-04-15",
+    "venue": {
+        "default": "Climate Pledge Arena"
+    },
+    "venueLocation": {
+        "default": "Seattle"
+    },
+    "startTimeUTC": "2025-04-16T02:30:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 309,
+            "market": "N",
+            "countryCode": "US",
+            "network": "ESPN",
+            "sequenceNumber": 10
+        },
+        {
+            "id": 283,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "SN360",
+            "sequenceNumber": 103
+        }
+    ],
+    "gameState": "OFF",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 26,
+        "commonName": {
+            "default": "Kings"
+        },
+        "abbrev": "LAK",
+        "score": 6,
+        "sog": 24,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/LAK_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/LAK_dark.svg",
+        "placeName": {
+            "default": "Los Angeles"
+        },
+        "placeNameWithPreposition": {
+            "default": "Los Angeles",
+            "fr": "de Los Angeles"
+        }
+    },
+    "homeTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 5,
+        "sog": 34,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 9,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8476479,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 67,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:11",
+            "timeRemaining": "19:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 10,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 26,
+                "playerId": 8476479
+            }
+        },
+        {
+            "eventId": 79,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 18,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8479421,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 61,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:15",
+            "timeRemaining": "18:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 19,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 20,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:18",
+            "timeRemaining": "18:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 23,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481532,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:19",
+            "timeRemaining": "18:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 24,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 66,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:34",
+            "timeRemaining": "18:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 25,
+            "details": {
+                "xCoord": -49,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8477960,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 151,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:06",
+            "timeRemaining": "17:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 35,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8482866,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 77,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:07",
+            "timeRemaining": "17:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 36,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482730,
+                "shootingPlayerId": 8481789,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 78,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:14",
+            "timeRemaining": "17:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 37,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479421,
+                "shootingPlayerId": 8482866,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 93,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:58",
+            "timeRemaining": "17:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 45,
+            "details": {
+                "xCoord": 97,
+                "yCoord": 13,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481606,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:16",
+            "timeRemaining": "16:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 46,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8476905,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 47,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "typeCode": "PS",
+                "descKey": "ps-hooking-on-breakaway",
+                "duration": 0,
+                "committedByPlayerId": 8478882,
+                "drawnByPlayerId": 8476905,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1010",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 51,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476905,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:19",
+            "timeRemaining": "16:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 54,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8482155,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 100,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:26",
+            "timeRemaining": "16:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 55,
+            "details": {
+                "xCoord": -2,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476457
+            }
+        },
+        {
+            "eventId": 96,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:05",
+            "timeRemaining": "15:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 61,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482408,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 98,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:09",
+            "timeRemaining": "15:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 62,
+            "details": {
+                "xCoord": 35,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 551,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 63,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "poke",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:13",
+            "timeRemaining": "15:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 64,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:13",
+            "timeRemaining": "15:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 67,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481532,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 113,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:34",
+            "timeRemaining": "15:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 68,
+            "details": {
+                "xCoord": 19,
+                "yCoord": 32,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 104,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 69,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483808,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 1,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 123,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 72,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 26,
+                "playerId": 8478452
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:50",
+            "timeRemaining": "15:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 73,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 124,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:51",
+            "timeRemaining": "15:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": 72,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8477335,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 127,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:26",
+            "timeRemaining": "14:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 81,
+            "details": {
+                "xCoord": -20,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482726,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 119,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:50",
+            "timeRemaining": "14:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 88,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:52",
+            "timeRemaining": "14:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 89,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:52",
+            "timeRemaining": "14:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 91,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8474586,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:08",
+            "timeRemaining": "13:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 92,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:08",
+            "timeRemaining": "13:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 94,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476479,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 140,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:22",
+            "timeRemaining": "13:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 95,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8476479
+            }
+        },
+        {
+            "eventId": 128,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:25",
+            "timeRemaining": "13:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 96,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8478882,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 129,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:26",
+            "timeRemaining": "13:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 97,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477998,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 2,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 130,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:28",
+            "timeRemaining": "13:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 98,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477998,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 141,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:34",
+            "timeRemaining": "12:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 107,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 150,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:54",
+            "timeRemaining": "12:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 115,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 376,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:33",
+            "timeRemaining": "11:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 122,
+            "details": {
+                "xCoord": -1,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8481532
+            }
+        },
+        {
+            "eventId": 358,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:40",
+            "timeRemaining": "11:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 124,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8473453,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 369,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:49",
+            "timeRemaining": "11:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 125,
+            "details": {
+                "xCoord": -14,
+                "yCoord": -28,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "playerId": 8480851
+            }
+        },
+        {
+            "eventId": 378,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 129,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "playerId": 8479591,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 387,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 130,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8478882
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:26",
+            "timeRemaining": "10:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 136,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:28",
+            "timeRemaining": "10:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 137,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 26,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:28",
+            "timeRemaining": "10:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 139,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 413,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:43",
+            "timeRemaining": "10:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 140,
+            "details": {
+                "xCoord": 64,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8477335,
+                "hitteePlayerId": 8481554
+            }
+        },
+        {
+            "eventId": 397,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:48",
+            "timeRemaining": "10:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 141,
+            "details": {
+                "xCoord": 25,
+                "yCoord": 8,
+                "zoneCode": "N",
+                "playerId": 8476457,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 415,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:26",
+            "timeRemaining": "09:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 150,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8479421,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 380,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:33",
+            "timeRemaining": "09:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 151,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479421,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 383,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:50",
+            "timeRemaining": "09:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 154,
+            "details": {
+                "xCoord": -27,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8481606,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 3,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 423,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 156,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8483808
+            }
+        },
+        {
+            "eventId": 449,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:48",
+            "timeRemaining": "08:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 168,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482726,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 461,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:28",
+            "timeRemaining": "07:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 176,
+            "details": {
+                "xCoord": 35,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8477998,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:30",
+            "timeRemaining": "07:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 177,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479675,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:57",
+            "timeRemaining": "07:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 182,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:59",
+            "timeRemaining": "07:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 183,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:59",
+            "timeRemaining": "07:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 186,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 429,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:54",
+            "timeRemaining": "06:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 197,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477960,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 464,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:11",
+            "timeRemaining": "05:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 200,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 16,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481532,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 446,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:30",
+            "timeRemaining": "05:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 204,
+            "details": {
+                "xCoord": 39,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 26,
+                "playerId": 8483808
+            }
+        },
+        {
+            "eventId": 154,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:53",
+            "timeRemaining": "05:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 212,
+            "details": {
+                "xCoord": 79,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478882,
+                "shootingPlayerId": 8474586,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 444,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 215,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8482726,
+                "scoringPlayerTotal": 3,
+                "assist1PlayerId": 8478882,
+                "assist1PlayerTotal": 24,
+                "assist2PlayerId": 8481606,
+                "assist2PlayerTotal": 23,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 1,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-helenius-scores-goal-against-joey-daccord-6371543340112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-helenius-marque-un-but-contre-joey-daccord-6371543609112",
+                "highlightClip": 6371543340112,
+                "highlightClipFr": 6371543609112,
+                "discreteClip": 6371542366112,
+                "discreteClipFr": 6371543520112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev444.json"
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 218,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476479,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 462,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:37",
+            "timeRemaining": "04:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 219,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:54",
+            "timeRemaining": "04:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 223,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 457,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:57",
+            "timeRemaining": "04:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 225,
+            "details": {
+                "xCoord": 0,
+                "yCoord": -30,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8481554,
+                "drawnByPlayerId": 8479675,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:57",
+            "timeRemaining": "04:03",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 227,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:57",
+            "timeRemaining": "04:03",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 230,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482408,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 231,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 232,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8481532,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 465,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:23",
+            "timeRemaining": "03:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 233,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8481532,
+                "scoringPlayerTotal": 9,
+                "assist1PlayerId": 8477960,
+                "assist1PlayerTotal": 38,
+                "assist2PlayerId": 8477942,
+                "assist2PlayerTotal": 24,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-turcotte-scores-ppg-against-joey-daccord-6371543149112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-turcotte-marque-un-but-en-a-n-contre-joey-daccord-6371544002112",
+                "highlightClip": 6371543149112,
+                "highlightClipFr": 6371544002112,
+                "discreteClip": 6371542270112,
+                "discreteClipFr": 6371544302112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev465.json"
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:23",
+            "timeRemaining": "03:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 237,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482155,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 238,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:34",
+            "timeRemaining": "03:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 239,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482155,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 471,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:04",
+            "timeRemaining": "02:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 240,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477444,
+                "shootingPlayerId": 8482730,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 482,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:10",
+            "timeRemaining": "02:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 241,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -27,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 483,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:15",
+            "timeRemaining": "01:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 250,
+            "details": {
+                "xCoord": 80,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481532,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 492,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:13",
+            "timeRemaining": "00:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 258,
+            "details": {
+                "xCoord": 44,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477335,
+                "shootingPlayerId": 8477955,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:35",
+            "timeRemaining": "00:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 262,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -27,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8480851,
+                "hitteePlayerId": 8482866
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:49",
+            "timeRemaining": "00:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 267,
+            "details": {
+                "xCoord": -23,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8479421
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 268
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 275
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 276,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 505,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:18",
+            "timeRemaining": "19:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 277,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8477998,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 506,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:22",
+            "timeRemaining": "19:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 278,
+            "details": {
+                "xCoord": 50,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476905,
+                "shootingPlayerId": 8481606,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 525,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:17",
+            "timeRemaining": "18:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 286,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8482408
+            }
+        },
+        {
+            "eventId": 519,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:56",
+            "timeRemaining": "18:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 292,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:06",
+            "timeRemaining": "17:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 294,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 522,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:13",
+            "timeRemaining": "17:47",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 296,
+            "details": {
+                "xCoord": 35,
+                "yCoord": -23,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8477335,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 528,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 298,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8478407,
+                "drawnByPlayerId": 8483808,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 300,
+            "details": {
+                "xCoord": -2,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "unsportsmanlike-conduct",
+                "duration": 2,
+                "committedByPlayerId": 8478407,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:31",
+            "timeRemaining": "17:29",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 304,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482408,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 531,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 305,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477960,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 532,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:35",
+            "timeRemaining": "17:25",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 306,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 533,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:56",
+            "timeRemaining": "17:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 307,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8477942,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 253,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:18",
+            "timeRemaining": "16:42",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 312,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477942,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:38",
+            "timeRemaining": "16:22",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 313,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477960,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 4,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 255,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:06",
+            "timeRemaining": "15:54",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 320,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8477998,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:48",
+            "timeRemaining": "15:12",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 324,
+            "details": {
+                "xCoord": -55,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 330,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477942,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 5,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:26",
+            "timeRemaining": "14:34",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 331,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8481789,
+                "scoringPlayerTotal": 6,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479496,
+                "awayScore": 2,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-kartye-scores-shg-against-david-rittich-6371543459112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-kartye-marque-un-but-en-i-n-contre-david-rittich-6371544222112",
+                "highlightClip": 6371543459112,
+                "highlightClipFr": 6371544222112,
+                "discreteClip": 6371545718112,
+                "discreteClipFr": 6371543279112
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:26",
+            "timeRemaining": "14:34",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 334,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8476479,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 615,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:40",
+            "timeRemaining": "14:20",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 335,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 26,
+                "playerId": 8482155
+            }
+        },
+        {
+            "eventId": 618,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:20",
+            "timeRemaining": "13:40",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 339,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 26,
+                "playerId": 8477998
+            }
+        },
+        {
+            "eventId": 613,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 344,
+            "details": {
+                "xCoord": -49,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478882,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:50",
+            "timeRemaining": "13:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 345,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:50",
+            "timeRemaining": "13:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 348,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8480851,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 620,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:52",
+            "timeRemaining": "13:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 349,
+            "details": {
+                "xCoord": -92,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8478882
+            }
+        },
+        {
+            "eventId": 629,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:12",
+            "timeRemaining": "12:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": -38,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8473453,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 633,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:32",
+            "timeRemaining": "12:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 352,
+            "details": {
+                "xCoord": -92,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8478882,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 621,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:37",
+            "timeRemaining": "12:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 353,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 28,
+                "zoneCode": "D",
+                "blockingPlayerId": 8473453,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 623,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:51",
+            "timeRemaining": "12:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 356,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480851,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:02",
+            "timeRemaining": "11:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 357,
+            "details": {
+                "xCoord": -29,
+                "yCoord": 20,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 639,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:09",
+            "timeRemaining": "11:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 358,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -13,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481606,
+                "hitteePlayerId": 8477401
+            }
+        },
+        {
+            "eventId": 627,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:19",
+            "timeRemaining": "11:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": -40,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 552,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:21",
+            "timeRemaining": "11:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 360,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:22",
+            "timeRemaining": "11:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 361,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:22",
+            "timeRemaining": "11:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 364,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8474586,
+                "winningPlayerId": 8482155,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:28",
+            "timeRemaining": "11:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 365,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:28",
+            "timeRemaining": "11:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 366,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482155,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 648,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:46",
+            "timeRemaining": "11:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 367,
+            "details": {
+                "xCoord": 89,
+                "yCoord": -27,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8477942,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 306,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:56",
+            "timeRemaining": "10:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 374,
+            "details": {
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 641,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:58",
+            "timeRemaining": "10:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 375,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 644,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:00",
+            "timeRemaining": "10:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 376,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -29,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8477335,
+                "drawnByPlayerId": 8482665,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 307,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:00",
+            "timeRemaining": "10:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 380,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 672,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:21",
+            "timeRemaining": "09:39",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 381,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8478882,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 658,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:22",
+            "timeRemaining": "09:38",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 382,
+            "details": {
+                "xCoord": -61,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "playerId": 8478882,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 660,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:33",
+            "timeRemaining": "08:27",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 392,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 663,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:46",
+            "timeRemaining": "08:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 393,
+            "details": {
+                "xCoord": -56,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477955,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 664,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:48",
+            "timeRemaining": "08:12",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 394,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479421,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:04",
+            "timeRemaining": "07:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 396,
+            "details": {
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 673,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:18",
+            "timeRemaining": "07:42",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 400,
+            "details": {
+                "xCoord": 12,
+                "yCoord": -14,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8476479,
+                "drawnByPlayerId": 8477955,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:18",
+            "timeRemaining": "07:42",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 402,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 310,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:18",
+            "timeRemaining": "07:42",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 405,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8473453,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 676,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:39",
+            "timeRemaining": "07:21",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 406,
+            "details": {
+                "xCoord": 47,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8473453,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 6,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 679,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 409,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 682,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:24",
+            "timeRemaining": "06:36",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 410,
+            "details": {
+                "xCoord": -37,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477986,
+                "scoringPlayerTotal": 18,
+                "assist1PlayerId": 8477444,
+                "assist1PlayerTotal": 27,
+                "assist2PlayerId": 8481554,
+                "assist2PlayerTotal": 30,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479496,
+                "awayScore": 2,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-montour-scores-ppg-against-david-rittich-6371545334112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-montour-marque-un-but-en-a-n-contre-david-rittich-6371544048112",
+                "highlightClip": 6371545334112,
+                "highlightClipFr": 6371544048112,
+                "discreteClip": 6371544244112,
+                "discreteClipFr": 6371545033112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev682.json"
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:24",
+            "timeRemaining": "06:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 414,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482726,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 687,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:35",
+            "timeRemaining": "06:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 415,
+            "details": {
+                "xCoord": 49,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480851,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 690,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:40",
+            "timeRemaining": "06:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": 52,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8473453,
+                "hitteePlayerId": 8479591
+            }
+        },
+        {
+            "eventId": 691,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:50",
+            "timeRemaining": "06:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 417,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 31,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8480851,
+                "hitteePlayerId": 8482866
+            }
+        },
+        {
+            "eventId": 688,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:06",
+            "timeRemaining": "05:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 418,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 419,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 313,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 422,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 314,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 423,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 315,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 424,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8482155,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 699,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:26",
+            "timeRemaining": "05:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 425,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482408,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 695,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:32",
+            "timeRemaining": "05:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 426,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 316,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 427,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 317,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 430,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481532,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 709,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 431,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8479421,
+                "hitteePlayerId": 8480009
+            }
+        },
+        {
+            "eventId": 712,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:34",
+            "timeRemaining": "04:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 441,
+            "details": {
+                "xCoord": 35,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 26,
+                "playerId": 8477998
+            }
+        },
+        {
+            "eventId": 318,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:44",
+            "timeRemaining": "04:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 442,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 319,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:44",
+            "timeRemaining": "04:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 443,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476479,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 713,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:48",
+            "timeRemaining": "04:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": 32,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8481606,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 7,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 714,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:05",
+            "timeRemaining": "03:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": 86,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8477998,
+                "scoringPlayerTotal": 24,
+                "assist1PlayerId": 8476479,
+                "assist1PlayerTotal": 35,
+                "assist2PlayerId": 8478882,
+                "assist2PlayerTotal": 25,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 3,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-foegele-scores-goal-against-joey-daccord-6371546126112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-foegele-marque-un-but-contre-joey-daccord-6371544343112",
+                "highlightClip": 6371546126112,
+                "highlightClipFr": 6371544343112,
+                "discreteClip": 6371545732112,
+                "discreteClipFr": 6371544944112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev714.json"
+        },
+        {
+            "eventId": 320,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:05",
+            "timeRemaining": "03:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 448,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482726,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 321,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:33",
+            "timeRemaining": "03:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 449,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 322,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:33",
+            "timeRemaining": "03:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 450,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482726,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 725,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:41",
+            "timeRemaining": "03:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 451,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8477335
+            }
+        },
+        {
+            "eventId": 720,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:48",
+            "timeRemaining": "03:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 452,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 323,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:58",
+            "timeRemaining": "03:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 453,
+            "details": {
+                "xCoord": -91,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "failed-bank-attempt",
+                "shotType": "cradle",
+                "shootingPlayerId": 8479591,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 324,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:04",
+            "timeRemaining": "02:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 454,
+            "details": {
+                "reason": "high-stick"
+            }
+        },
+        {
+            "eventId": 325,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:04",
+            "timeRemaining": "02:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 457,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8482665,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 326,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:15",
+            "timeRemaining": "02:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 458,
+            "details": {
+                "xCoord": 81,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477942,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 8,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 726,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 459,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8482155,
+                "scoringPlayerTotal": 19,
+                "assist1PlayerId": 8477942,
+                "assist1PlayerTotal": 25,
+                "assist2PlayerId": 8482408,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 4,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-laferriere-scores-goal-against-joey-daccord-6371543853112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-laferriere-marque-un-but-contre-joey-daccord-6371544144112",
+                "highlightClip": 6371543853112,
+                "highlightClipFr": 6371544144112,
+                "discreteClip": 6371544948112,
+                "discreteClipFr": 6371543382112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev726.json"
+        },
+        {
+            "eventId": 327,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 460,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 801,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:45",
+            "timeRemaining": "02:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 463,
+            "details": {
+                "xCoord": 26,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "playerId": 8482858,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 806,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:03",
+            "timeRemaining": "01:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 465,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481532,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 809,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 475,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481532,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 807,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:50",
+            "timeRemaining": "01:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 476,
+            "details": {
+                "xCoord": 6,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478407
+            }
+        },
+        {
+            "eventId": 741,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:52",
+            "timeRemaining": "01:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 477,
+            "details": {
+                "xCoord": 59,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477960,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 9,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 744,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:14",
+            "timeRemaining": "00:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 479,
+            "details": {
+                "xCoord": 36,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8479421,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 10,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 745,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:23",
+            "timeRemaining": "00:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 480,
+            "details": {
+                "xCoord": 67,
+                "yCoord": 5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8482730,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 328,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:40",
+            "timeRemaining": "00:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 487,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 329,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:40",
+            "timeRemaining": "00:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 489,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476479,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:44",
+            "timeRemaining": "00:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 490,
+            "details": {
+                "xCoord": -93,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "playerId": 8477955,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 330,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 491
+        },
+        {
+            "eventId": 336,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 498
+        },
+        {
+            "eventId": 335,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 499,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 812,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:10",
+            "timeRemaining": "19:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 500,
+            "details": {
+                "xCoord": 65,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 813,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:24",
+            "timeRemaining": "19:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 501,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:26",
+            "timeRemaining": "19:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 502,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 338,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:26",
+            "timeRemaining": "19:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 505,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:27",
+            "timeRemaining": "19:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 506,
+            "details": {
+                "xCoord": 67,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482730,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 818,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:36",
+            "timeRemaining": "19:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 507,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482408,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 11,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 828,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:41",
+            "timeRemaining": "19:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 508,
+            "details": {
+                "xCoord": -92,
+                "yCoord": -29,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482155,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 339,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:48",
+            "timeRemaining": "19:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 509,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 340,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:48",
+            "timeRemaining": "19:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 512,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481532,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 823,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:15",
+            "timeRemaining": "18:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 513,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481532,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 830,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:26",
+            "timeRemaining": "18:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 514,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476457
+            }
+        },
+        {
+            "eventId": 824,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:27",
+            "timeRemaining": "18:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 515,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8483808,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 825,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:41",
+            "timeRemaining": "18:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 516,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477960,
+                "scoringPlayerTotal": 35,
+                "assist1PlayerId": 8481532,
+                "assist1PlayerTotal": 16,
+                "assist2PlayerId": 8483808,
+                "assist2PlayerTotal": 26,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 5,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-kempe-scores-goal-against-joey-daccord-6371544163112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-kempe-marque-un-but-contre-joey-daccord-6371545361112",
+                "highlightClip": 6371544163112,
+                "highlightClipFr": 6371545361112,
+                "discreteClip": 6371546353112,
+                "discreteClipFr": 6371544963112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev825.json"
+        },
+        {
+            "eventId": 341,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:41",
+            "timeRemaining": "18:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 519,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482155,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 342,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:07",
+            "timeRemaining": "17:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 520,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 343,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:07",
+            "timeRemaining": "17:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 522,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8482726,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:18",
+            "timeRemaining": "17:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 523,
+            "details": {
+                "xCoord": -51,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480851,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 847,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:32",
+            "timeRemaining": "17:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 526,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -17,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482726,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 836,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:36",
+            "timeRemaining": "17:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 528,
+            "details": {
+                "xCoord": -28,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8479421,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 12,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 837,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:38",
+            "timeRemaining": "17:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 529,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8482726,
+                "scoringPlayerTotal": 4,
+                "assist1PlayerId": 8479421,
+                "assist1PlayerTotal": 7,
+                "assist2PlayerId": 8473453,
+                "assist2PlayerTotal": 6,
+                "eventOwnerTeamId": 26,
+                "goalieInNetId": 8478916,
+                "awayScore": 6,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-helenius-scores-goal-against-joey-daccord-6371546151112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-helenius-marque-un-but-contre-joey-daccord-6371546051112",
+                "highlightClip": 6371546151112,
+                "highlightClipFr": 6371546051112,
+                "discreteClip": 6371545561112,
+                "discreteClipFr": 6371545261112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev837.json"
+        },
+        {
+            "eventId": 344,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:38",
+            "timeRemaining": "17:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 532,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 843,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:20",
+            "timeRemaining": "16:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 533,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8481606,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 345,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 534,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 346,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 537,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480851,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 848,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 538,
+            "details": {
+                "xCoord": -35,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8477335,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 347,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:27",
+            "timeRemaining": "16:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 539,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 348,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:27",
+            "timeRemaining": "16:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 540,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8473453,
+                "winningPlayerId": 8477955,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 850,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:29",
+            "timeRemaining": "16:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 541,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8482726,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 851,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:30",
+            "timeRemaining": "16:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 542,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8473453,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 852,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:35",
+            "timeRemaining": "16:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 543,
+            "details": {
+                "xCoord": -32,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8477335,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 13,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 349,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 544,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 350,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 545,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8480851,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 866,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 546,
+            "details": {
+                "xCoord": 52,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8473453,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 854,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:02",
+            "timeRemaining": "15:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 870,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:09",
+            "timeRemaining": "15:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": 52,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8482726,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 855,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8473453,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 857,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:29",
+            "timeRemaining": "15:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482726,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 14,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 751,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:31",
+            "timeRemaining": "15:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 554,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 752,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:31",
+            "timeRemaining": "15:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 557,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481532,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 868,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:36",
+            "timeRemaining": "15:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 558,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476467
+            }
+        },
+        {
+            "eventId": 863,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:12",
+            "timeRemaining": "14:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 26,
+                "assist1PlayerId": 8476467,
+                "assist1PlayerTotal": 13,
+                "assist2PlayerId": 8482866,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479496,
+                "awayScore": 6,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-schwartz-scores-goal-against-david-rittich-6371544168112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-schwartz-marque-un-but-contre-david-rittich-6371543981112",
+                "highlightClip": 6371544168112,
+                "highlightClipFr": 6371543981112,
+                "discreteClip": 6371544363112,
+                "discreteClipFr": 6371544679112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev863.json"
+        },
+        {
+            "eventId": 753,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:12",
+            "timeRemaining": "14:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 562,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8477401,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 882,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:23",
+            "timeRemaining": "14:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 563,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 26,
+                "playerId": 8477942
+            }
+        },
+        {
+            "eventId": 869,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:39",
+            "timeRemaining": "14:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 564,
+            "details": {
+                "xCoord": 58,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 554,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:49",
+            "timeRemaining": "14:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 565,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8477942,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 881,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:25",
+            "timeRemaining": "13:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 575,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479675,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 15,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 884,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:35",
+            "timeRemaining": "13:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 577,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478452,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 894,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:25",
+            "timeRemaining": "12:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 587,
+            "details": {
+                "xCoord": 34,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 754,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:27",
+            "timeRemaining": "12:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 588,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 755,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:27",
+            "timeRemaining": "12:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 591,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8481532,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 899,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:42",
+            "timeRemaining": "12:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 592,
+            "details": {
+                "xCoord": 31,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482866,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 756,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:45",
+            "timeRemaining": "12:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 593,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:45",
+            "timeRemaining": "12:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 594,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481532,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 912,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:00",
+            "timeRemaining": "12:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 595,
+            "details": {
+                "xCoord": -96,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8477960
+            }
+        },
+        {
+            "eventId": 916,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:25",
+            "timeRemaining": "11:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": 89,
+                "yCoord": -26,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8481606,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 908,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:51",
+            "timeRemaining": "11:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 605,
+            "details": {
+                "xCoord": -60,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482155,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 16,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 553,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:52",
+            "timeRemaining": "11:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 606,
+            "details": {
+                "xCoord": -87,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477986,
+                "shootingPlayerId": 8482155,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:11",
+            "timeRemaining": "10:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 608,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482155,
+                "shootingPlayerId": 8480009,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:12",
+            "timeRemaining": "10:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 609,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 259,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:12",
+            "timeRemaining": "10:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 610,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 913,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 611,
+            "details": {
+                "xCoord": 31,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 760,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:34",
+            "timeRemaining": "10:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 612,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 761,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:34",
+            "timeRemaining": "10:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 615,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8477955,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 919,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:39",
+            "timeRemaining": "10:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 616,
+            "details": {
+                "xCoord": -58,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8477998,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 762,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:41",
+            "timeRemaining": "10:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 617,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 763,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:41",
+            "timeRemaining": "10:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 618,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476479,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 921,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:43",
+            "timeRemaining": "10:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": -28,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8477335,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 764,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:45",
+            "timeRemaining": "10:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 620,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 765,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:45",
+            "timeRemaining": "10:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 621,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8477955,
+                "winningPlayerId": 8476479,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 923,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:55",
+            "timeRemaining": "10:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 622,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477335,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 953,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:03",
+            "timeRemaining": "09:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 623,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8478452,
+                "hitteePlayerId": 8477444
+            }
+        },
+        {
+            "eventId": 955,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:40",
+            "timeRemaining": "09:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 634,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8478882
+            }
+        },
+        {
+            "eventId": 935,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -23,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480851,
+                "shootingPlayerId": 8482866,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 766,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:27",
+            "timeRemaining": "08:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 642,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 767,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:27",
+            "timeRemaining": "08:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 643,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481532,
+                "winningPlayerId": 8475768,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 946,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:31",
+            "timeRemaining": "08:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 644,
+            "details": {
+                "xCoord": 51,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 947,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:40",
+            "timeRemaining": "08:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 645,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 24,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 768,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:59",
+            "timeRemaining": "08:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 649,
+            "details": {
+                "reason": "referee-or-linesman",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 769,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:59",
+            "timeRemaining": "08:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 652,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482155,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 973,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:02",
+            "timeRemaining": "07:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 653,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "playerId": 8474586,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 957,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:04",
+            "timeRemaining": "07:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 654,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 770,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:05",
+            "timeRemaining": "07:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 655,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 771,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:05",
+            "timeRemaining": "07:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 656,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 161,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:08",
+            "timeRemaining": "07:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 657,
+            "details": {
+                "xCoord": 65,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 260,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:15",
+            "timeRemaining": "07:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 658,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 977,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:57",
+            "timeRemaining": "07:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477986,
+                "hitteePlayerId": 8477942
+            }
+        },
+        {
+            "eventId": 981,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 667,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -16,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 26,
+                "hittingPlayerId": 8477942,
+                "hitteePlayerId": 8477986
+            }
+        },
+        {
+            "eventId": 966,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:04",
+            "timeRemaining": "06:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 668,
+            "details": {
+                "xCoord": -45,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478882,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 17,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 970,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:12",
+            "timeRemaining": "06:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 670,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8476479,
+                "drawnByPlayerId": 8477444,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 772,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:12",
+            "timeRemaining": "06:48",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 674,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477998,
+                "winningPlayerId": 8475768,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:34",
+            "timeRemaining": "06:26",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 675,
+            "details": {
+                "xCoord": 86,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8482665,
+                "scoringPlayerTotal": 20,
+                "assist1PlayerId": 8474586,
+                "assist1PlayerTotal": 17,
+                "assist2PlayerId": 8477955,
+                "assist2PlayerTotal": 39,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479496,
+                "awayScore": 6,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-beniers-scores-ppg-against-david-rittich-6371543884112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-beniers-marque-un-but-en-a-n-contre-david-rittich-6371543883112",
+                "highlightClip": 6371543884112,
+                "highlightClipFr": 6371543883112,
+                "discreteClip": 6371545685112,
+                "discreteClipFr": 6371545577112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev975.json"
+        },
+        {
+            "eventId": 773,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:34",
+            "timeRemaining": "06:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 679,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482726,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 994,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 680,
+            "details": {
+                "xCoord": -28,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "playerId": 8476467,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 982,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:06",
+            "timeRemaining": "05:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 681,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480851,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 261,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:25",
+            "timeRemaining": "05:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 686,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -9,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8477960,
+                "eventOwnerTeamId": 26,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 996,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:37",
+            "timeRemaining": "05:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 26,
+                "playerId": 8481532
+            }
+        },
+        {
+            "eventId": 774,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:58",
+            "timeRemaining": "05:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 692,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:58",
+            "timeRemaining": "05:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 695,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482155,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 995,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 696,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478882,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 26,
+                "awaySOG": 18,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 1064,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:59",
+            "timeRemaining": "03:01",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 714,
+            "details": {
+                "xCoord": 35,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 1068,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:28",
+            "timeRemaining": "02:32",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 717,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478882,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1071,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 718,
+            "details": {
+                "xCoord": 88,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8482726,
+                "drawnByPlayerId": 8474586,
+                "eventOwnerTeamId": 26
+            }
+        },
+        {
+            "eventId": 776,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 720,
+            "details": {
+                "reason": "home-timeout",
+                "secondaryReason": "home-timeout"
+            }
+        },
+        {
+            "eventId": 777,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 722,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8476479,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1076,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:03",
+            "timeRemaining": "00:57",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 726,
+            "details": {
+                "xCoord": 65,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477986,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 778,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:05",
+            "timeRemaining": "00:55",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 727,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 779,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:05",
+            "timeRemaining": "00:55",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 730,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476479,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1081,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:08",
+            "timeRemaining": "00:52",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 731,
+            "details": {
+                "xCoord": 37,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 1083,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:20",
+            "timeRemaining": "00:40",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 732,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8479496,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 1084,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:30",
+            "timeRemaining": "00:30",
+            "situationCode": "1460",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 733,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8480009,
+                "scoringPlayerTotal": 23,
+                "assist1PlayerId": 8483524,
+                "assist1PlayerTotal": 25,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 28,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8479496,
+                "awayScore": 6,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/lak-sea-tolvanen-scores-ppg-against-david-rittich-6371545170112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/lak-sea-tolvanen-marque-un-but-en-a-n-contre-david-rittich-6371546646112",
+                "highlightClip": 6371545170112,
+                "highlightClipFr": 6371546646112,
+                "discreteClip": 6371546450112,
+                "discreteClipFr": 6371545382112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20242025/2024021300/ev1084.json"
+        },
+        {
+            "eventId": 780,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:30",
+            "timeRemaining": "00:30",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 737,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8476905,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1092,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:43",
+            "timeRemaining": "00:17",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 738,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478407,
+                "hitteePlayerId": 8482730
+            }
+        },
+        {
+            "eventId": 781,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 739,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 782,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 740,
+            "details": {
+                "eventOwnerTeamId": 26,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8482155,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 783,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:52",
+            "timeRemaining": "00:08",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 741,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 784,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:52",
+            "timeRemaining": "00:08",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 743,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482155,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 785,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 744
+        },
+        {
+            "eventId": 789,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 748
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 26,
+            "playerId": 8473453,
+            "firstName": {
+                "default": "Trevor"
+            },
+            "lastName": {
+                "default": "Lewis"
+            },
+            "sweaterNumber": 61,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8473453.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8474586.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8475311,
+            "firstName": {
+                "default": "Darcy"
+            },
+            "lastName": {
+                "default": "Kuemper"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8475311.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8475831.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476467.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8476479,
+            "firstName": {
+                "default": "Phillip"
+            },
+            "lastName": {
+                "default": "Danault"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8476479.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8476905.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8477335,
+            "firstName": {
+                "default": "Kyle"
+            },
+            "lastName": {
+                "default": "Burroughs"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8477335.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477444,
+            "firstName": {
+                "default": "Andre",
+                "cs": "Andr\u00e9",
+                "sk": "Andr\u00e9",
+                "sv": "Andr\u00e9"
+            },
+            "lastName": {
+                "default": "Burakovsky"
+            },
+            "sweaterNumber": 95,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477444.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8477942,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Fiala"
+            },
+            "sweaterNumber": 22,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8477942.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477955,
+            "firstName": {
+                "default": "Jared"
+            },
+            "lastName": {
+                "default": "McCann"
+            },
+            "sweaterNumber": 19,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477955.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8477960,
+            "firstName": {
+                "default": "Adrian"
+            },
+            "lastName": {
+                "default": "Kempe"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8477960.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477986,
+            "firstName": {
+                "default": "Brandon"
+            },
+            "lastName": {
+                "default": "Montour"
+            },
+            "sweaterNumber": 62,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8477986.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8477998,
+            "firstName": {
+                "default": "Warren"
+            },
+            "lastName": {
+                "default": "Foegele"
+            },
+            "sweaterNumber": 37,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8477998.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478407.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8478452,
+            "firstName": {
+                "default": "Caleb"
+            },
+            "lastName": {
+                "default": "Jones"
+            },
+            "sweaterNumber": 82,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8478452.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8478882,
+            "firstName": {
+                "default": "Vladislav"
+            },
+            "lastName": {
+                "default": "Gavrikov"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8478882.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8478916.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8479421,
+            "firstName": {
+                "default": "Jacob"
+            },
+            "lastName": {
+                "default": "Moverare"
+            },
+            "sweaterNumber": 43,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8479421.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8479496,
+            "firstName": {
+                "default": "David"
+            },
+            "lastName": {
+                "default": "Rittich"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8479496.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479591,
+            "firstName": {
+                "default": "Michael"
+            },
+            "lastName": {
+                "default": "Eyssimont"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8479591.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8479675,
+            "firstName": {
+                "default": "Trevor"
+            },
+            "lastName": {
+                "default": "Moore"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8479675.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8480009.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8480851,
+            "firstName": {
+                "default": "Akil"
+            },
+            "lastName": {
+                "default": "Thomas"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8480851.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8481532,
+            "firstName": {
+                "default": "Alex"
+            },
+            "lastName": {
+                "default": "Turcotte"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8481532.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481554.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8481606,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Spence"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8481606.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8481789.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8482155,
+            "firstName": {
+                "default": "Alex"
+            },
+            "lastName": {
+                "default": "Laferriere"
+            },
+            "sweaterNumber": 14,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8482155.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8482408,
+            "firstName": {
+                "default": "Jeff"
+            },
+            "lastName": {
+                "default": "Malott",
+                "cs": "Malottt",
+                "de": "Malottt",
+                "es": "Malottt",
+                "fi": "Malottt",
+                "sk": "Malottt",
+                "sv": "Malottt"
+            },
+            "sweaterNumber": 39,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8482408.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482665.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8482726,
+            "firstName": {
+                "default": "Samuel"
+            },
+            "lastName": {
+                "default": "Helenius"
+            },
+            "sweaterNumber": 79,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8482726.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8482730,
+            "firstName": {
+                "default": "Brandt"
+            },
+            "lastName": {
+                "default": "Clarke"
+            },
+            "sweaterNumber": 92,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8482730.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482866,
+            "firstName": {
+                "default": "Ville"
+            },
+            "lastName": {
+                "default": "Ottavainen"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8482866.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/SEA/8483524.png"
+        },
+        {
+            "teamId": 26,
+            "playerId": 8483808,
+            "firstName": {
+                "default": "Andrei",
+                "cs": "Andrej",
+                "sk": "Andrej"
+            },
+            "lastName": {
+                "default": "Kuzmenko"
+            },
+            "sweaterNumber": 96,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20242025/LAK/8483808.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -99,3 +99,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #79: Seattle Kraken vs Utah Hockey Club - Seattle loses 7-1](./2024-25/regular-season/20250408-SEA-vs-UTA-2024021243.json)
 - [GAME #80: Seattle Kraken vs Vegas Golden Knights - Seattle loses 2-1](./2024-25/regular-season/20250410-SEA-vs-VGK-2024021258.json)
 - [GAME #81: St. Louis Blues vs Seattle Kraken - Seattle wins 4-3 in SO](./2024-25/regular-season/20250412-STL-vs-SEA-2024021275.json)
+- [GAME #82: Los Angeles Kings vs Seattle Kraken - Seattle loses 6-5](./2024-25/regular-season/20250415-LAK-vs-SEA-2024021300.json)


### PR DESCRIPTION
# Description

Add data and README entry for the final Seattle Kraken game of the 2024-25 NHL season (April 15, 2025: Kraken vs Kings, LAK 6 - SEA 5).

## Type of Change

version: chore    # General maintenance

## Testing

- [x] I have verified correct file placement and README update per project conventions
- [x] Downloaded data for correct date and teams
- [x] All changes committed and pushed on branch 2025.04.15/kraken

---
This PR follows the project’s NHL data and PR conventions for game data additions.