### PR TITLE
feat: Add Kraken 2025-26 preseason opener data from September 21st, 2025

### DIFF
--- a/data/NHL - National Hockey League/2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json
+++ b/data/NHL - National Hockey League/2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json
@@ -1,0 +1,7675 @@
+{
+    "id": 2025010011,
+    "season": 20252026,
+    "gameType": 1,
+    "limitedScoring": false,
+    "gameDate": "2025-09-21",
+    "venue": {
+        "default": "Climate Pledge Arena"
+    },
+    "venueLocation": {
+        "default": "Seattle"
+    },
+    "startTimeUTC": "2025-09-22T00:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 554,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 388,
+            "market": "H",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 23,
+        "commonName": {
+            "default": "Canucks"
+        },
+        "abbrev": "VAN",
+        "score": 3,
+        "sog": 25,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/VAN_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/VAN_dark.svg",
+        "placeName": {
+            "default": "Vancouver"
+        },
+        "placeNameWithPreposition": {
+            "default": "Vancouver",
+            "fr": "de Vancouver"
+        }
+    },
+    "homeTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 5,
+        "sog": 24,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 8
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8484800,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 63,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:31",
+            "timeRemaining": "19:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8474586,
+                "hitteePlayerId": 8483678
+            }
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:00",
+            "timeRemaining": "19:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 21,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8480078
+            }
+        },
+        {
+            "eventId": 62,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:09",
+            "timeRemaining": "18:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 22,
+            "details": {
+                "xCoord": 29,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 101,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:11",
+            "timeRemaining": "18:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:17",
+            "timeRemaining": "18:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 24,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:17",
+            "timeRemaining": "18:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 26,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:27",
+            "timeRemaining": "18:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 27,
+            "details": {
+                "xCoord": 52,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8475768,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:49",
+            "timeRemaining": "18:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 30,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 74,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:49",
+            "timeRemaining": "18:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 31,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 76,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:51",
+            "timeRemaining": "18:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 32,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8481486,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 86,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:11",
+            "timeRemaining": "17:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 37,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8484168,
+                "hitteePlayerId": 8476927
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:28",
+            "timeRemaining": "17:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 39,
+            "details": {
+                "xCoord": 51,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 40,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 82,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 42,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8477401,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 85,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:35",
+            "timeRemaining": "17:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 43,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8485383,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 91,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:03",
+            "timeRemaining": "16:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 48,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8480058,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:58",
+            "timeRemaining": "16:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 62,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:07",
+            "timeRemaining": "15:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 64,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 0,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:21",
+            "timeRemaining": "15:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 66,
+            "details": {
+                "reason": "net-dislodged-offensive-skater"
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:21",
+            "timeRemaining": "15:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 69,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8482665,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 178,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:29",
+            "timeRemaining": "15:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 70,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476927,
+                "hitteePlayerId": 8485389
+            }
+        },
+        {
+            "eventId": 169,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:33",
+            "timeRemaining": "15:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 71,
+            "details": {
+                "xCoord": -13,
+                "yCoord": -22,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8481554
+            }
+        },
+        {
+            "eventId": 174,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:42",
+            "timeRemaining": "15:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 72,
+            "details": {
+                "xCoord": -47,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8476927
+            }
+        },
+        {
+            "eventId": 175,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:45",
+            "timeRemaining": "15:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 73,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 184,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:47",
+            "timeRemaining": "15:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": -29,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8483678
+            }
+        },
+        {
+            "eventId": 163,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:51",
+            "timeRemaining": "15:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 75,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476927,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 164,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:55",
+            "timeRemaining": "15:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 76,
+            "details": {
+                "xCoord": -41,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 1,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 181,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:38",
+            "timeRemaining": "14:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 85,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8482858,
+                "drawnByPlayerId": 8481535,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 176,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:38",
+            "timeRemaining": "14:22",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 89,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8481535,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 189,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:27",
+            "timeRemaining": "13:33",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 94,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 315,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:54",
+            "timeRemaining": "13:06",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 102,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483395,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 200,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:31",
+            "timeRemaining": "12:29",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 106,
+            "details": {
+                "xCoord": -70,
+                "yCoord": 18,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477467,
+                "shootingPlayerId": 8484202,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 310,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:49",
+            "timeRemaining": "12:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 116,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476425,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 103,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:00",
+            "timeRemaining": "12:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 118,
+            "details": {
+                "xCoord": 3,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:03",
+            "timeRemaining": "11:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 120,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 313,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:03",
+            "timeRemaining": "11:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 123,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:11",
+            "timeRemaining": "11:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 124,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 318,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:11",
+            "timeRemaining": "11:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 126,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 321,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:13",
+            "timeRemaining": "11:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 127,
+            "details": {
+                "xCoord": 59,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:15",
+            "timeRemaining": "11:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 128,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 322,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:15",
+            "timeRemaining": "11:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 130,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477401,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 329,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:22",
+            "timeRemaining": "11:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 131,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482918,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 325,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:31",
+            "timeRemaining": "11:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 132,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 326,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:37",
+            "timeRemaining": "11:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 133,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477401,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 333,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:40",
+            "timeRemaining": "11:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 134,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482918,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 327,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:47",
+            "timeRemaining": "11:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 135,
+            "details": {
+                "xCoord": 43,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:49",
+            "timeRemaining": "11:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 136,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 328,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:49",
+            "timeRemaining": "11:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 139,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 345,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:04",
+            "timeRemaining": "10:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 140,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483768,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 341,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:08",
+            "timeRemaining": "10:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 141,
+            "details": {
+                "xCoord": 90,
+                "yCoord": -31,
+                "zoneCode": "D",
+                "playerId": 8480078,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 356,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:30",
+            "timeRemaining": "10:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 143,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481535,
+                "hitteePlayerId": 8476467
+            }
+        },
+        {
+            "eventId": 344,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:57",
+            "timeRemaining": "10:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 151,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -33,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482496,
+                "shootingPlayerId": 8485389,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 104,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:16",
+            "timeRemaining": "09:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 154,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 369,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:18",
+            "timeRemaining": "09:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 155,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476425,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 358,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:51",
+            "timeRemaining": "09:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 165,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8483395,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:34",
+            "timeRemaining": "08:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 174,
+            "details": {
+                "reason": "puck-in-benches",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 367,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:34",
+            "timeRemaining": "08:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 176,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8476927,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 392,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:48",
+            "timeRemaining": "08:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 177,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477401,
+                "hitteePlayerId": 8484202
+            }
+        },
+        {
+            "eventId": 202,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:58",
+            "timeRemaining": "08:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 178,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476467,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 373,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:09",
+            "timeRemaining": "07:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 180,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8482055,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 181,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 2,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 374,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:12",
+            "timeRemaining": "07:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 182,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 3,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 204,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:54",
+            "timeRemaining": "07:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 191,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 385,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:02",
+            "timeRemaining": "06:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 193,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480078,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 4,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 194,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 388,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 197,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476425,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 393,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:06",
+            "timeRemaining": "06:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 198,
+            "details": {
+                "xCoord": -43,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483768,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 5,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:07",
+            "timeRemaining": "06:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 199,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 394,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:07",
+            "timeRemaining": "06:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 200,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8482496,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 396,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:09",
+            "timeRemaining": "06:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483442,
+                "shootingPlayerId": 8480058,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 464,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:24",
+            "timeRemaining": "06:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 203,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476425,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 454,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:48",
+            "timeRemaining": "06:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 211,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 463,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:56",
+            "timeRemaining": "06:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 214,
+            "details": {
+                "xCoord": -15,
+                "yCoord": 15,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8483395
+            }
+        },
+        {
+            "eventId": 458,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:06",
+            "timeRemaining": "05:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 215,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8484222,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8474586,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8485389,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8484268,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-sale-scores-goal-against-nikita-tolopilo-6379900046112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-sale-marque-un-but-contre-nikita-tolopilo-6379898967112",
+                "highlightClip": 6379900046112,
+                "highlightClipFr": 6379898967112,
+                "discreteClip": 6379899353112,
+                "discreteClipFr": 6379899755112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev458.json"
+        },
+        {
+            "eventId": 459,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:06",
+            "timeRemaining": "05:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 218,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8476927,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:08",
+            "timeRemaining": "05:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 219,
+            "details": {
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 220,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 468,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 221,
+            "details": {
+                "xCoord": 23,
+                "yCoord": 12,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8482918,
+                "drawnByPlayerId": 8484168,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 465,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 225,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 477,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:30",
+            "timeRemaining": "05:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 226,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484240,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 107,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 239,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8483497,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 499,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:20",
+            "timeRemaining": "03:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 248,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 494,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:31",
+            "timeRemaining": "03:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 250,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480078,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 495,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:45",
+            "timeRemaining": "03:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 251,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481486,
+                "shootingPlayerId": 8484168,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:03",
+            "timeRemaining": "02:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 255,
+            "details": {
+                "xCoord": -40,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483442,
+                "shootingPlayerId": 8484202,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 108,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 260,
+            "details": {
+                "xCoord": 81,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 27,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:18",
+            "timeRemaining": "02:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 261,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:18",
+            "timeRemaining": "02:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 263,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 507,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:20",
+            "timeRemaining": "02:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 264,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 12,
+                "zoneCode": "O",
+                "blockingPlayerId": 8475768,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 511,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:27",
+            "timeRemaining": "02:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 265,
+            "details": {
+                "xCoord": 0,
+                "yCoord": -36,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476425,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 266,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "cross-checking",
+                "duration": 2,
+                "committedByPlayerId": 8477401,
+                "drawnByPlayerId": 8476425,
+                "servedByPlayerId": 8485383,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 268,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "instigator",
+                "duration": 2,
+                "committedByPlayerId": 8477401,
+                "drawnByPlayerId": 8476425,
+                "servedByPlayerId": 8485383,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 28,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 270,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8476425,
+                "drawnByPlayerId": 8477401,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 272,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "typeCode": "MAJ",
+                "descKey": "fighting",
+                "duration": 5,
+                "committedByPlayerId": 8477401,
+                "drawnByPlayerId": 8476425,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 274,
+            "details": {
+                "xCoord": -62,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "typeCode": "MIS",
+                "descKey": "instigator-misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8477401,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 508,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:34",
+            "timeRemaining": "02:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 278,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8480078,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 516,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:47",
+            "timeRemaining": "02:13",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 279,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 6,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:49",
+            "timeRemaining": "02:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 280,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 517,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:49",
+            "timeRemaining": "02:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 282,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 528,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:51",
+            "timeRemaining": "02:09",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 283,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "playerId": 8484240,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 529,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:18",
+            "timeRemaining": "01:42",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 286,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "playerId": 8481554,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 522,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:21",
+            "timeRemaining": "01:39",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 288,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484240,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:23",
+            "timeRemaining": "01:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 289,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 523,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:23",
+            "timeRemaining": "01:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 292,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8474586,
+                "winningPlayerId": 8485385,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 530,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:12",
+            "timeRemaining": "00:48",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 293,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483395,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 43,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:23",
+            "timeRemaining": "00:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 297,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 534,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:23",
+            "timeRemaining": "00:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 300,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8475768,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 538,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:41",
+            "timeRemaining": "00:19",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 301,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 540,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:56",
+            "timeRemaining": "00:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 302,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 7,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 303,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 541,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 306,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 307
+        },
+        {
+            "eventId": 549,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 313
+        },
+        {
+            "eventId": 548,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 315,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8483524,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 550,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:23",
+            "timeRemaining": "19:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 316,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8484240,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 325,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 559,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 327,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8485385,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 566,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 328,
+            "details": {
+                "xCoord": 23,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8483395
+            }
+        },
+        {
+            "eventId": 567,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:32",
+            "timeRemaining": "18:28",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 329,
+            "details": {
+                "xCoord": 3,
+                "yCoord": -20,
+                "zoneCode": "N",
+                "typeCode": "MIN",
+                "descKey": "high-sticking",
+                "duration": 2,
+                "committedByPlayerId": 8475768,
+                "drawnByPlayerId": 8485385,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 562,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:32",
+            "timeRemaining": "18:28",
+            "situationCode": "1531",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 333,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480078,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 571,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:38",
+            "timeRemaining": "18:22",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 335,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 587,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:25",
+            "timeRemaining": "16:35",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": 59,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8483768,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8485385,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8480748,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8478916,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-mancini-scores-ppg-against-joey-daccord-6379898085112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-mancini-marque-un-but-en-a-n-contre-joey-daccord-6379900178112",
+                "highlightClip": 6379898085112,
+                "highlightClipFr": 6379900178112,
+                "discreteClip": 6379898300112,
+                "discreteClipFr": 6379900752112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev587.json"
+        },
+        {
+            "eventId": 588,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:25",
+            "timeRemaining": "16:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 355,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8476927,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 403,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:02",
+            "timeRemaining": "15:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 357,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 594,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:02",
+            "timeRemaining": "15:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 360,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8483524,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 404,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:22",
+            "timeRemaining": "15:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 361,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 600,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:22",
+            "timeRemaining": "15:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 364,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8480078,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 610,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:32",
+            "timeRemaining": "15:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": -11,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483442
+            }
+        },
+        {
+            "eventId": 607,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 366,
+            "details": {
+                "xCoord": 18,
+                "yCoord": 34,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481486,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 609,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:46",
+            "timeRemaining": "15:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 367,
+            "details": {
+                "xCoord": 0,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483442,
+                "hitteePlayerId": 8481486
+            }
+        },
+        {
+            "eventId": 405,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:59",
+            "timeRemaining": "15:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 369,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 605,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:59",
+            "timeRemaining": "15:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 371,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8485385,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 618,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:03",
+            "timeRemaining": "13:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 379,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "blockingPlayerId": 8474586,
+                "shootingPlayerId": 8478407,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 619,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:17",
+            "timeRemaining": "13:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 380,
+            "details": {
+                "xCoord": -47,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 628,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:30",
+            "timeRemaining": "13:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 382,
+            "details": {
+                "xCoord": -20,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8476425
+            }
+        },
+        {
+            "eventId": 625,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:56",
+            "timeRemaining": "13:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 387,
+            "details": {
+                "xCoord": -47,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8485389,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:58",
+            "timeRemaining": "13:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 388,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 626,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:58",
+            "timeRemaining": "13:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 390,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 642,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:59",
+            "timeRemaining": "12:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 398,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "playerId": 8483524,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:59",
+            "timeRemaining": "12:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 399,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 23,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483524
+            }
+        },
+        {
+            "eventId": 649,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:59",
+            "timeRemaining": "12:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 400,
+            "details": {
+                "xCoord": 90,
+                "yCoord": 31,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483524,
+                "hitteePlayerId": 8480748
+            }
+        },
+        {
+            "eventId": 637,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:01",
+            "timeRemaining": "11:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8480748,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 638,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:04",
+            "timeRemaining": "11:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 402,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8484202,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 658,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:44",
+            "timeRemaining": "11:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 408,
+            "details": {
+                "xCoord": -43,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481486,
+                "hitteePlayerId": 8483442
+            }
+        },
+        {
+            "eventId": 659,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:47",
+            "timeRemaining": "11:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 410,
+            "details": {
+                "xCoord": -91,
+                "yCoord": 32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 647,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:51",
+            "timeRemaining": "11:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 411,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481486,
+                "shootingPlayerId": 8476467,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 109,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 413,
+            "details": {
+                "xCoord": -59,
+                "yCoord": -4,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483476,
+                "shootingPlayerId": 8475768,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 667,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:09",
+            "timeRemaining": "10:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 416,
+            "details": {
+                "xCoord": -89,
+                "yCoord": 32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481486,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 669,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:13",
+            "timeRemaining": "10:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 417,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480078,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:15",
+            "timeRemaining": "10:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 418,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8485383
+            }
+        },
+        {
+            "eventId": 670,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:24",
+            "timeRemaining": "10:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 420,
+            "details": {
+                "xCoord": 49,
+                "yCoord": 35,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8483476
+            }
+        },
+        {
+            "eventId": 407,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 421,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 654,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 423,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8485383,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 253,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:52",
+            "timeRemaining": "10:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 427,
+            "details": {
+                "xCoord": 16,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482496,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 8,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 408,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:03",
+            "timeRemaining": "09:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 429,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 665,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:03",
+            "timeRemaining": "09:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 432,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8476927,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 409,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:09",
+            "timeRemaining": "09:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 433,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 671,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:09",
+            "timeRemaining": "09:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 434,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8476927,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 677,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:23",
+            "timeRemaining": "09:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 435,
+            "details": {
+                "xCoord": -23,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484202,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 410,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:24",
+            "timeRemaining": "09:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 436,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 673,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:24",
+            "timeRemaining": "09:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 439,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480078,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 678,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:54",
+            "timeRemaining": "09:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 440,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8483497,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8481554,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8483751,
+                "awayScore": 1,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-nyman-scores-goal-against-ty-young-6379901748112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-nyman-marque-un-but-contre-ty-young-6379899000112",
+                "highlightClip": 6379901748112,
+                "highlightClipFr": 6379899000112,
+                "discreteClip": 6379901550112,
+                "discreteClipFr": 6379899101112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev678.json"
+        },
+        {
+            "eventId": 679,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:54",
+            "timeRemaining": "09:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 443,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8482496,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 690,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:00",
+            "timeRemaining": "09:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8484240
+            }
+        },
+        {
+            "eventId": 693,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:11",
+            "timeRemaining": "08:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 445,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482714,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 685,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:25",
+            "timeRemaining": "08:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 449,
+            "details": {
+                "xCoord": 40,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476425,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:26",
+            "timeRemaining": "08:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 451,
+            "details": {
+                "xCoord": 44,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8476425
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:28",
+            "timeRemaining": "08:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 452,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 688,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:28",
+            "timeRemaining": "08:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 455,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480748,
+                "winningPlayerId": 8483524,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 697,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:42",
+            "timeRemaining": "08:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 456,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "holding",
+                "duration": 2,
+                "committedByPlayerId": 8483768,
+                "drawnByPlayerId": 8483442,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 694,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:42",
+            "timeRemaining": "08:18",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 460,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:01",
+            "timeRemaining": "07:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 461,
+            "details": {
+                "reason": "high-stick"
+            }
+        },
+        {
+            "eventId": 702,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:01",
+            "timeRemaining": "07:59",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 463,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8482665,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 110,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:35",
+            "timeRemaining": "07:25",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 464,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483678,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 713,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:07",
+            "timeRemaining": "06:53",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 473,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8474586,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 413,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:08",
+            "timeRemaining": "06:52",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 474,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 714,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:08",
+            "timeRemaining": "06:52",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 476,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8475768,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 718,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:45",
+            "timeRemaining": "06:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 478,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8475768,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8483524,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 2,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8483751,
+                "awayScore": 1,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-schwartz-scores-goal-against-ty-young-6379899794112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-schwartz-marque-un-but-contre-ty-young-6379899005112",
+                "highlightClip": 6379899794112,
+                "highlightClipFr": 6379899005112,
+                "discreteClip": 6379901451112,
+                "discreteClipFr": 6379900195112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev718.json"
+        },
+        {
+            "eventId": 719,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:45",
+            "timeRemaining": "06:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 481,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480078,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 414,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:05",
+            "timeRemaining": "05:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 482,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 723,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:05",
+            "timeRemaining": "05:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 484,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 111,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:09",
+            "timeRemaining": "05:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 485,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481535,
+                "shootingPlayerId": 8482665,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 726,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:25",
+            "timeRemaining": "05:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 486,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "scoringPlayerId": 8483497,
+                "scoringPlayerTotal": 2,
+                "assist1PlayerId": 8481554,
+                "assist1PlayerTotal": 2,
+                "assist2PlayerId": 8478407,
+                "assist2PlayerTotal": 3,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8483751,
+                "awayScore": 1,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-nyman-scores-goal-against-ty-young-6379899495112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-nyman-marque-un-but-contre-ty-young-6379899214112",
+                "highlightClip": 6379899495112,
+                "highlightClipFr": 6379899214112,
+                "discreteClip": 6379901754112,
+                "discreteClipFr": 6379901656112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev726.json"
+        },
+        {
+            "eventId": 727,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:25",
+            "timeRemaining": "05:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 489,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8485383,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 112,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:29",
+            "timeRemaining": "05:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 490,
+            "details": {
+                "xCoord": -8,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8483442,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 732,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:36",
+            "timeRemaining": "05:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 491,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477467,
+                "hitteePlayerId": 8482714
+            }
+        },
+        {
+            "eventId": 731,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:59",
+            "timeRemaining": "05:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 492,
+            "details": {
+                "xCoord": -66,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483395,
+                "shootingPlayerId": 8485389,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 113,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:18",
+            "timeRemaining": "04:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 493,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "slap",
+                "shootingPlayerId": 8477467,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 752,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:51",
+            "timeRemaining": "04:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 504,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 415,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 510,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 748,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:16",
+            "timeRemaining": "03:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 513,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8483524,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 763,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 514,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 19,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484202,
+                "hitteePlayerId": 8483524
+            }
+        },
+        {
+            "eventId": 416,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 521,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:12",
+            "timeRemaining": "02:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 524,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 764,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:32",
+            "timeRemaining": "02:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 525,
+            "details": {
+                "xCoord": 67,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "reason": "high-and-wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 777,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:06",
+            "timeRemaining": "01:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 531,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483395,
+                "hitteePlayerId": 8485389
+            }
+        },
+        {
+            "eventId": 784,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 534,
+            "details": {
+                "xCoord": -91,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484168
+            }
+        },
+        {
+            "eventId": 785,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:07",
+            "timeRemaining": "00:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 542,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 417,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:18",
+            "timeRemaining": "00:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 544,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "backhand",
+                "shootingPlayerId": 8484800,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 783,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:29",
+            "timeRemaining": "00:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 545,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8478407,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 792,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:35",
+            "timeRemaining": "00:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 546,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476425,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 786,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:42",
+            "timeRemaining": "00:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482714,
+                "goalieInNetId": 8478916,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 9,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 418,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:44",
+            "timeRemaining": "00:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 549,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "typeCode": "PS",
+                "descKey": "ps-slash-on-breakaway",
+                "duration": 0,
+                "committedByPlayerId": 8478407,
+                "drawnByPlayerId": 8482714,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 421,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:44",
+            "timeRemaining": "00:16",
+            "situationCode": "0101",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8482714,
+                "scoringPlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8478916,
+                "awayScore": 2,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-stillman-scores-goal-against-joey-daccord-6379901950112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-stillman-marque-un-but-contre-joey-daccord-6379901263112",
+                "highlightClip": 6379901950112,
+                "highlightClipFr": 6379901263112,
+                "discreteClip": 6379899805112,
+                "discreteClipFr": 6379901364112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev421.json"
+        },
+        {
+            "eventId": 787,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:44",
+            "timeRemaining": "00:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 556,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 794,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:54",
+            "timeRemaining": "00:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 557,
+            "details": {
+                "xCoord": 89,
+                "yCoord": 17,
+                "zoneCode": "D",
+                "playerId": 8482055,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 422,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 558
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 565
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 567,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8485385,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 809,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 569,
+            "details": {
+                "xCoord": -97,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:46",
+            "timeRemaining": "19:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 575,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482714,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:03",
+            "timeRemaining": "18:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 580,
+            "details": {
+                "xCoord": -50,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481486,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 10,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 114,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:05",
+            "timeRemaining": "18:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 581,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481535,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 819,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 589,
+            "details": {
+                "xCoord": -49,
+                "yCoord": -31,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 11,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 430,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 590,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 820,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 591,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 255,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:50",
+            "timeRemaining": "18:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 592,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 822,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:18",
+            "timeRemaining": "17:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 593,
+            "details": {
+                "xCoord": 34,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477467,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 831,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:30",
+            "timeRemaining": "17:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 596,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482055,
+                "hitteePlayerId": 8485389
+            }
+        },
+        {
+            "eventId": 836,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:49",
+            "timeRemaining": "17:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 600,
+            "details": {
+                "xCoord": 99,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8485383
+            }
+        },
+        {
+            "eventId": 115,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:01",
+            "timeRemaining": "16:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 602,
+            "details": {
+                "xCoord": 61,
+                "yCoord": 30,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482055,
+                "shootingPlayerId": 8477401,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 431,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:02",
+            "timeRemaining": "16:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 603,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 829,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:02",
+            "timeRemaining": "16:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 605,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482496,
+                "winningPlayerId": 8485383,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 833,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:07",
+            "timeRemaining": "16:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 606,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8477401,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8484168,
+                "assist1PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8483751,
+                "awayScore": 2,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-hayden-scores-goal-against-ty-young-6379902064112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-hayden-marque-un-but-contre-ty-young-6379899521112",
+                "highlightClip": 6379902064112,
+                "highlightClipFr": 6379899521112,
+                "discreteClip": 6379900674112,
+                "discreteClipFr": 6379900117112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev833.json"
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:07",
+            "timeRemaining": "16:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 608,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8482496,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 846,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:22",
+            "timeRemaining": "16:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 609,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 911,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:21",
+            "timeRemaining": "15:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": 36,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8476457,
+                "hitteePlayerId": 8485385
+            }
+        },
+        {
+            "eventId": 919,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:30",
+            "timeRemaining": "15:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 624,
+            "details": {
+                "xCoord": 3,
+                "yCoord": 12,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484800
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:42",
+            "timeRemaining": "15:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 628,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8485389,
+                "shootingPlayerId": 8481535,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 909,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:07",
+            "timeRemaining": "14:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 631,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 910,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:11",
+            "timeRemaining": "14:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 632,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 925,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:22",
+            "timeRemaining": "14:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 634,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481554,
+                "hitteePlayerId": 8482055
+            }
+        },
+        {
+            "eventId": 432,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:55",
+            "timeRemaining": "14:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 641,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 920,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:55",
+            "timeRemaining": "14:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 644,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8485383,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 924,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:57",
+            "timeRemaining": "14:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 645,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476457,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 931,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:02",
+            "timeRemaining": "13:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 646,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 33,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "playerId": 8482918
+            }
+        },
+        {
+            "eventId": 926,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:05",
+            "timeRemaining": "13:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 647,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477401,
+                "shootingPlayerId": 8476457,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 942,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:26",
+            "timeRemaining": "13:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 652,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481486,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 934,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:34",
+            "timeRemaining": "13:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 655,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478407,
+                "shootingPlayerId": 8476425,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 937,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:49",
+            "timeRemaining": "13:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 658,
+            "details": {
+                "xCoord": -60,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483524,
+                "shootingPlayerId": 8483476,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 938,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:10",
+            "timeRemaining": "12:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 659,
+            "details": {
+                "xCoord": -31,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481486,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 256,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:25",
+            "timeRemaining": "12:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 660,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8482496,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8476425,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8480058,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8483668,
+                "awayScore": 3,
+                "homeScore": 5,
+                "highlightClipSharingUrl": "https://nhl.com/video/van-sea-aman-scores-goal-against-niklas-kokko-6379901476112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/van-sea-aman-marque-un-but-contre-niklas-kokko-6379900314112",
+                "highlightClip": 6379901476112,
+                "highlightClipFr": 6379900314112,
+                "discreteClip": 6379900982112,
+                "discreteClipFr": 6379902262112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010011/ev256.json"
+        },
+        {
+            "eventId": 939,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:25",
+            "timeRemaining": "12:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 663,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8484800,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 944,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:43",
+            "timeRemaining": "12:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 664,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483395,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 12,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 956,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:55",
+            "timeRemaining": "12:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 665,
+            "details": {
+                "xCoord": 7,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483678,
+                "hitteePlayerId": 8474586
+            }
+        },
+        {
+            "eventId": 961,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:18",
+            "timeRemaining": "11:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 672,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8481535,
+                "hitteePlayerId": 8482665
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:43",
+            "timeRemaining": "11:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 675,
+            "details": {
+                "xCoord": -40,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482665,
+                "hitteePlayerId": 8480078
+            }
+        },
+        {
+            "eventId": 433,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 676,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 953,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:53",
+            "timeRemaining": "11:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 678,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 957,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 679,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482665,
+                "shootingPlayerId": 8481486,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 434,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:06",
+            "timeRemaining": "10:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 680,
+            "details": {
+                "reason": "puck-frozen",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 958,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:06",
+            "timeRemaining": "10:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 683,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483524,
+                "winningPlayerId": 8476927,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 964,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:07",
+            "timeRemaining": "10:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 684,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 13,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:08",
+            "timeRemaining": "10:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 685,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 965,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:20",
+            "timeRemaining": "10:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 686,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482055,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 15,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 966,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:48",
+            "timeRemaining": "10:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476457,
+                "shootingPlayerId": 8482055,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 987,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:19",
+            "timeRemaining": "09:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 695,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 34,
+                "zoneCode": "D",
+                "playerId": 8485383,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 990,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:34",
+            "timeRemaining": "08:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 711,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 16,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 435,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:36",
+            "timeRemaining": "08:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 713,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 992,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:36",
+            "timeRemaining": "08:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 716,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1007,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:43",
+            "timeRemaining": "08:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 717,
+            "details": {
+                "xCoord": 39,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482665
+            }
+        },
+        {
+            "eventId": 1008,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:04",
+            "timeRemaining": "07:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 718,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 32,
+                "zoneCode": "O",
+                "playerId": 8481554,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 997,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:07",
+            "timeRemaining": "07:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 719,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1003,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:17",
+            "timeRemaining": "07:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 722,
+            "details": {
+                "xCoord": -90,
+                "yCoord": -28,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "interference",
+                "duration": 2,
+                "committedByPlayerId": 8476457,
+                "drawnByPlayerId": 8482714,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1000,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:17",
+            "timeRemaining": "07:43",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 726,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480748,
+                "winningPlayerId": 8483524,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1009,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:54",
+            "timeRemaining": "07:06",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 727,
+            "details": {
+                "xCoord": -71,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8485385,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 17,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 1018,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:27",
+            "timeRemaining": "06:33",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 734,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "playerId": 8483476,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 1025,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:31",
+            "timeRemaining": "06:29",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 735,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8483476
+            }
+        },
+        {
+            "eventId": 1017,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:57",
+            "timeRemaining": "06:03",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 736,
+            "details": {
+                "xCoord": -54,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 18,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 1029,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:31",
+            "timeRemaining": "05:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 746,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481554,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1030,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:36",
+            "timeRemaining": "05:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 747,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482665,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 436,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 748,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 1031,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 751,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8485383,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 437,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 752,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 1035,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:46",
+            "timeRemaining": "05:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 754,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8476927,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1040,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:54",
+            "timeRemaining": "05:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 755,
+            "details": {
+                "xCoord": 11,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482055,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 438,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 756,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 1038,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:09",
+            "timeRemaining": "04:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 757,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1051,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:42",
+            "timeRemaining": "04:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 763,
+            "details": {
+                "xCoord": -73,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482496,
+                "hitteePlayerId": 8478407
+            }
+        },
+        {
+            "eventId": 1050,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:04",
+            "timeRemaining": "03:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 768,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1052,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:36",
+            "timeRemaining": "03:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 769,
+            "details": {
+                "xCoord": 54,
+                "yCoord": -9,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483524,
+                "goalieInNetId": 8483751,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 1058,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:44",
+            "timeRemaining": "03:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 775,
+            "details": {
+                "xCoord": -28,
+                "yCoord": -7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8481535,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1067,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:51",
+            "timeRemaining": "03:09",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 778,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8480058
+            }
+        },
+        {
+            "eventId": 205,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:57",
+            "timeRemaining": "03:03",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 779,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 258,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:58",
+            "timeRemaining": "03:02",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 780,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 1065,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:28",
+            "timeRemaining": "02:32",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 784,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8485385,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 259,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:41",
+            "timeRemaining": "02:19",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 785,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 20,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 1080,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:22",
+            "timeRemaining": "01:38",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 792,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8476457
+            }
+        },
+        {
+            "eventId": 1082,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:25",
+            "timeRemaining": "01:35",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 793,
+            "details": {
+                "xCoord": -62,
+                "yCoord": 40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480078,
+                "hitteePlayerId": 8475768
+            }
+        },
+        {
+            "eventId": 439,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:26",
+            "timeRemaining": "01:34",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 794,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1073,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:30",
+            "timeRemaining": "01:30",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 795,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 21,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 1077,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 796,
+            "details": {
+                "xCoord": -55,
+                "yCoord": 27,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8475768,
+                "drawnByPlayerId": 8481535,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1074,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 800,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8482665,
+                "winningPlayerId": 8480078,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 440,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:52",
+            "timeRemaining": "01:08",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 801,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 1083,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:52",
+            "timeRemaining": "01:08",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 802,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480078,
+                "winningPlayerId": 8482665,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1085,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:57",
+            "timeRemaining": "01:03",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 803,
+            "details": {
+                "xCoord": 24,
+                "yCoord": -11,
+                "zoneCode": "N",
+                "blockingPlayerId": 8483678,
+                "shootingPlayerId": 8481554,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 1086,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:36",
+            "timeRemaining": "00:24",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 804,
+            "details": {
+                "xCoord": -65,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 22,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 441,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:46",
+            "timeRemaining": "00:14",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 805,
+            "details": {
+                "xCoord": -59,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "above-crossbar",
+                "shotType": "snap",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8483668,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 1088,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:57",
+            "timeRemaining": "00:03",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 806,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476467,
+                "shootingPlayerId": 8483476,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 442,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 807
+        },
+        {
+            "eventId": 446,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "0641",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 811
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 55,
+            "playerId": 8474586,
+            "firstName": {
+                "default": "Jordan"
+            },
+            "lastName": {
+                "default": "Eberle"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8474586.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475768,
+            "firstName": {
+                "default": "Jaden"
+            },
+            "lastName": {
+                "default": "Schwartz"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8475768.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8476425,
+            "firstName": {
+                "default": "Joseph"
+            },
+            "lastName": {
+                "default": "LaBate",
+                "cs": "Labate",
+                "de": "Labate",
+                "fi": "Labate",
+                "sk": "Labate",
+                "sv": "Labate"
+            },
+            "sweaterNumber": 14,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8476425.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476457,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Larsson"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8476457.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476467,
+            "firstName": {
+                "default": "Jamie"
+            },
+            "lastName": {
+                "default": "Oleksiak"
+            },
+            "sweaterNumber": 24,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8476467.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8476927,
+            "firstName": {
+                "default": "Teddy",
+                "cs": "Theodors",
+                "sk": "Theodors"
+            },
+            "lastName": {
+                "default": "Blueger",
+                "cs": "Blugers",
+                "sk": "Blugers"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8476927.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477401,
+            "firstName": {
+                "default": "John"
+            },
+            "lastName": {
+                "default": "Hayden"
+            },
+            "sweaterNumber": 15,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8477401.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477467,
+            "firstName": {
+                "default": "Gustav"
+            },
+            "lastName": {
+                "default": "Olofsson"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8477467.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478407,
+            "firstName": {
+                "default": "Vince"
+            },
+            "lastName": {
+                "default": "Dunn"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8478407.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478916,
+            "firstName": {
+                "default": "Joey"
+            },
+            "lastName": {
+                "default": "Daccord"
+            },
+            "sweaterNumber": 35,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8478916.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480058,
+            "firstName": {
+                "default": "P.O",
+                "cs": "Pierre-Olivier",
+                "de": "Pierre-Olivier",
+                "es": "Pierre-Olivier",
+                "fi": "Pierre-Olivier",
+                "sk": "Pierre-Olivier",
+                "sv": "Pierre-Olivier"
+            },
+            "lastName": {
+                "default": "Joseph"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480058.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480078,
+            "firstName": {
+                "default": "Filip"
+            },
+            "lastName": {
+                "default": "Chytil"
+            },
+            "sweaterNumber": 72,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480078.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480748,
+            "firstName": {
+                "default": "Kiefer"
+            },
+            "lastName": {
+                "default": "Sherwood"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480748.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8481486,
+            "firstName": {
+                "default": "Jimmy"
+            },
+            "lastName": {
+                "default": "Schuldt"
+            },
+            "sweaterNumber": 48,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8481486.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8481535,
+            "firstName": {
+                "default": "Nils"
+            },
+            "lastName": {
+                "default": "Hoglander",
+                "cs": "H\u00f6glander",
+                "fi": "H\u00f6glander",
+                "sk": "H\u00f6glander",
+                "sv": "H\u00f6glander"
+            },
+            "sweaterNumber": 21,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8481535.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481554,
+            "firstName": {
+                "default": "Kaapo"
+            },
+            "lastName": {
+                "default": "Kakko"
+            },
+            "sweaterNumber": 84,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8481554.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482055,
+            "firstName": {
+                "default": "Drew"
+            },
+            "lastName": {
+                "default": "O'Connor"
+            },
+            "sweaterNumber": 18,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482055.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482496,
+            "firstName": {
+                "default": "Nils"
+            },
+            "lastName": {
+                "default": "Aman",
+                "fi": "\u00c5man",
+                "sv": "\u00c5man"
+            },
+            "sweaterNumber": 88,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482496.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482665,
+            "firstName": {
+                "default": "Matty"
+            },
+            "lastName": {
+                "default": "Beniers"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482665.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482714,
+            "firstName": {
+                "default": "Chase"
+            },
+            "lastName": {
+                "default": "Stillman"
+            },
+            "sweaterNumber": 61,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482714.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482858.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482918,
+            "firstName": {
+                "default": "Danila"
+            },
+            "lastName": {
+                "default": "Klimovich"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482918.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483395,
+            "firstName": {
+                "default": "Arshdeep"
+            },
+            "lastName": {
+                "default": "Bains"
+            },
+            "sweaterNumber": 13,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483395.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483442,
+            "firstName": {
+                "default": "Jagger"
+            },
+            "lastName": {
+                "default": "Firkus"
+            },
+            "sweaterNumber": 57,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483442.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483476,
+            "firstName": {
+                "default": "Jonathan"
+            },
+            "lastName": {
+                "default": "Lekkerim\u00e4ki"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483476.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483524,
+            "firstName": {
+                "default": "Shane"
+            },
+            "lastName": {
+                "default": "Wright"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483524.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483668,
+            "firstName": {
+                "default": "Nikke"
+            },
+            "lastName": {
+                "default": "Kokko"
+            },
+            "sweaterNumber": 39,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483668.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483678,
+            "firstName": {
+                "default": "Elias"
+            },
+            "lastName": {
+                "default": "Pettersson"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483678.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483751,
+            "firstName": {
+                "default": "Ty"
+            },
+            "lastName": {
+                "default": "Young"
+            },
+            "sweaterNumber": 85,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483751.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483768,
+            "firstName": {
+                "default": "Victor"
+            },
+            "lastName": {
+                "default": "Mancini"
+            },
+            "sweaterNumber": 90,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484168,
+            "firstName": {
+                "default": "Oscar"
+            },
+            "lastName": {
+                "default": "Fisker Molgaard"
+            },
+            "sweaterNumber": 78,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484168.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484202,
+            "firstName": {
+                "default": "Sawyer"
+            },
+            "lastName": {
+                "default": "Mynio"
+            },
+            "sweaterNumber": 45,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484202.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484222,
+            "firstName": {
+                "default": "Eduard"
+            },
+            "lastName": {
+                "default": "Sale"
+            },
+            "sweaterNumber": 82,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484222.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484240,
+            "firstName": {
+                "default": "Tom"
+            },
+            "lastName": {
+                "default": "Willander"
+            },
+            "sweaterNumber": 5,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484240.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484268,
+            "firstName": {
+                "default": "Nikita"
+            },
+            "lastName": {
+                "default": "Tolopilo"
+            },
+            "sweaterNumber": 60,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484268.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484800,
+            "firstName": {
+                "default": "Berkly"
+            },
+            "lastName": {
+                "default": "Catton"
+            },
+            "sweaterNumber": 77,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484800.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8485383,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "O'Brien"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8485383.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8485385,
+            "firstName": {
+                "default": "Braeden"
+            },
+            "lastName": {
+                "default": "Cootes"
+            },
+            "sweaterNumber": 80,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8485385.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8485389,
+            "firstName": {
+                "default": "Blake"
+            },
+            "lastName": {
+                "default": "Fiddler"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8485389.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -100,3 +100,7 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [GAME #80: Seattle Kraken vs Vegas Golden Knights - Seattle loses 2-1](./2024-25/regular-season/20250410-SEA-vs-VGK-2024021258.json)
 - [GAME #81: St. Louis Blues vs Seattle Kraken - Seattle wins 4-3 in SO](./2024-25/regular-season/20250412-STL-vs-SEA-2024021275.json)
 - [GAME #82: Los Angeles Kings vs Seattle Kraken - Seattle loses 6-5](./2024-25/regular-season/20250415-LAK-vs-SEA-2024021300.json)
+
+### 2025-26 Preseason
+
+- [PRESEASON GAME #1: Vancouver Canucks vs Seattle Kraken - Seattle wins 5-3](./2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json)


### PR DESCRIPTION
# Description

Added data for the Seattle Kraken 2025-26 preseason opener game against the Vancouver Canucks on September 21st, 2025. The Kraken won with a score of 5-3.

This PR includes:
- Game data file from NHL API (Game ID: 2025010011)
- Updated README.md with the new game information in the 2025-26 preseason section, including the score and result

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG