### PR TITLE
feat: Add Kraken vs Flames preseason game data from September 23rd, 2025

### DIFF
--- a/data/NHL - National Hockey League/2025-26/preseason/20250923-SEA-vs-CGY-2025010027.json
+++ b/data/NHL - National Hockey League/2025-26/preseason/20250923-SEA-vs-CGY-2025010027.json
@@ -1,0 +1,7297 @@
+{
+    "id": 2025010027,
+    "season": 20252026,
+    "gameType": 1,
+    "limitedScoring": false,
+    "gameDate": "2025-09-23",
+    "venue": {
+        "default": "Scotiabank Saddledome"
+    },
+    "venueLocation": {
+        "default": "Calgary"
+    },
+    "startTimeUTC": "2025-09-24T01:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-06:00",
+    "tvBroadcasts": [
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 1,
+        "sog": 20,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 20,
+        "commonName": {
+            "default": "Flames"
+        },
+        "abbrev": "CGY",
+        "score": 4,
+        "sog": 34,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/CGY_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/CGY_dark.svg",
+        "placeName": {
+            "default": "Calgary"
+        },
+        "placeNameWithPreposition": {
+            "default": "Calgary",
+            "fr": "de Calgary"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 9
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480028,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:22",
+            "timeRemaining": "19:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -22,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 59,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:34",
+            "timeRemaining": "19:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 17,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 0,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 101,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:44",
+            "timeRemaining": "19:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 22,
+            "details": {
+                "xCoord": 2,
+                "yCoord": -1,
+                "zoneCode": "N",
+                "shotType": "backhand",
+                "shootingPlayerId": 8477919,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 68,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:50",
+            "timeRemaining": "19:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 23,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482165
+            }
+        },
+        {
+            "eventId": 64,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:52",
+            "timeRemaining": "19:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 24,
+            "details": {
+                "xCoord": 40,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479372,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 10,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:53",
+            "timeRemaining": "19:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 25,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 65,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:53",
+            "timeRemaining": "19:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 27,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8483609,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 70,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:20",
+            "timeRemaining": "18:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 29,
+            "details": {
+                "xCoord": -43,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8477993,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 2,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:20",
+            "timeRemaining": "18:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 30,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8477993
+            }
+        },
+        {
+            "eventId": 79,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:07",
+            "timeRemaining": "17:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 39,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 27,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484800,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:13",
+            "timeRemaining": "17:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 41,
+            "details": {
+                "xCoord": 91,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483010,
+                "hitteePlayerId": 8482209
+            }
+        },
+        {
+            "eventId": 11,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:25",
+            "timeRemaining": "17:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 46,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 84,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:25",
+            "timeRemaining": "17:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 48,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8478477,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 217,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 49,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -24,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483449,
+                "hitteePlayerId": 8482165
+            }
+        },
+        {
+            "eventId": 12,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:24",
+            "timeRemaining": "16:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 56,
+            "details": {
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 203,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:41",
+            "timeRemaining": "16:19",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 60,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "holding",
+                "duration": 2,
+                "committedByPlayerId": 8480028,
+                "drawnByPlayerId": 8482858,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 98,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:41",
+            "timeRemaining": "16:19",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 64,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477993,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:23",
+            "timeRemaining": "15:37",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 68,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8481167,
+                "hitteePlayerId": 8476905
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:15",
+            "timeRemaining": "14:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 75,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 218,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:15",
+            "timeRemaining": "14:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 77,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8484821,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:06",
+            "timeRemaining": "13:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 88,
+            "details": {
+                "xCoord": -19,
+                "yCoord": 3,
+                "zoneCode": "N",
+                "shotType": "snap",
+                "shootingPlayerId": 8480028,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 3,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 238,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:35",
+            "timeRemaining": "13:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 96,
+            "details": {
+                "xCoord": 0,
+                "yCoord": -39,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484433,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 250,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:48",
+            "timeRemaining": "13:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 98,
+            "details": {
+                "xCoord": 45,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8476905
+            }
+        },
+        {
+            "eventId": 271,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:58",
+            "timeRemaining": "13:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 101,
+            "details": {
+                "xCoord": -89,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8477993,
+                "hitteePlayerId": 8484433
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:04",
+            "timeRemaining": "12:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 102,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 154,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:24",
+            "timeRemaining": "12:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 107,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484433,
+                "shootingPlayerId": 8482074,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:26",
+            "timeRemaining": "12:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 108,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 247,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:26",
+            "timeRemaining": "12:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 111,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8482209,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 280,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:33",
+            "timeRemaining": "12:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 112,
+            "details": {
+                "xCoord": -29,
+                "yCoord": 38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8484860
+            }
+        },
+        {
+            "eventId": 253,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:40",
+            "timeRemaining": "12:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 113,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8481068,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8484150,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8482209,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8475831,
+                "awayScore": 0,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-sharangovich-scores-goal-against-philipp-grubauer-6380017642112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-sharangovich-marque-un-but-contre-philipp-grubauer-6380017742112",
+                "highlightClip": 6380017642112,
+                "highlightClipFr": 6380017742112,
+                "discreteClip": 6380017448112,
+                "discreteClipFr": 6380016254112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010027/ev253.json"
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:40",
+            "timeRemaining": "12:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 116,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8484821,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 309,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:54",
+            "timeRemaining": "12:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 117,
+            "details": {
+                "xCoord": 47,
+                "yCoord": -38,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8482470,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 258,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:06",
+            "timeRemaining": "11:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 118,
+            "details": {
+                "xCoord": 41,
+                "yCoord": 27,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482766,
+                "shootingPlayerId": 8479372,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:25",
+            "timeRemaining": "11:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 119,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 260,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:25",
+            "timeRemaining": "11:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 122,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 312,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:37",
+            "timeRemaining": "11:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 123,
+            "details": {
+                "xCoord": 19,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8480860
+            }
+        },
+        {
+            "eventId": 102,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:11",
+            "timeRemaining": "10:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 125,
+            "details": {
+                "xCoord": 68,
+                "yCoord": 13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484768,
+                "shootingPlayerId": 8478975,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 265,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:14",
+            "timeRemaining": "10:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 126,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "scoringPlayerId": 8478477,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8478975,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8480009,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8481692,
+                "awayScore": 1,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-stephens-scores-goal-against-dustin-wolf-6380017759112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-stephens-marque-un-but-contre-dustin-wolf-6380019716112",
+                "highlightClip": 6380017759112,
+                "highlightClipFr": 6380019716112,
+                "discreteClip": 6380018171112,
+                "discreteClipFr": 6380019517112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010027/ev265.json"
+        },
+        {
+            "eventId": 266,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:14",
+            "timeRemaining": "10:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 129,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8478477,
+                "winningPlayerId": 8477993,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 289,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:34",
+            "timeRemaining": "10:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 130,
+            "details": {
+                "xCoord": -11,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8483609
+            }
+        },
+        {
+            "eventId": 274,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 134,
+            "details": {
+                "xCoord": -42,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483609,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 4,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:56",
+            "timeRemaining": "10:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 135,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 275,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:56",
+            "timeRemaining": "10:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 138,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8481068,
+                "winningPlayerId": 8477919,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:19",
+            "timeRemaining": "07:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 159,
+            "details": {
+                "xCoord": -50,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:30",
+            "timeRemaining": "07:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 162,
+            "details": {
+                "reason": "puck-in-crowd",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:30",
+            "timeRemaining": "07:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 165,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8478477,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 103,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:52",
+            "timeRemaining": "07:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 166,
+            "details": {
+                "xCoord": 73,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "hit-right-post",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8478477,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 311,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:15",
+            "timeRemaining": "06:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 168,
+            "details": {
+                "xCoord": -35,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480860,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 169,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 313,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 172,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8482209,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 385,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:23",
+            "timeRemaining": "06:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 173,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8480860
+            }
+        },
+        {
+            "eventId": 155,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:34",
+            "timeRemaining": "06:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 174,
+            "details": {
+                "xCoord": -88,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484860,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 317,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:52",
+            "timeRemaining": "06:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 175,
+            "details": {
+                "xCoord": -58,
+                "yCoord": -35,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477919,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 337,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:32",
+            "timeRemaining": "04:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 194,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484219,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 104,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:37",
+            "timeRemaining": "04:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 195,
+            "details": {
+                "xCoord": 77,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8484219,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:39",
+            "timeRemaining": "04:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 196,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 339,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:39",
+            "timeRemaining": "04:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 199,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 105,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:53",
+            "timeRemaining": "04:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 200,
+            "details": {
+                "xCoord": 33,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "reason": "short",
+                "shotType": "slap",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 343,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:07",
+            "timeRemaining": "03:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 201,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 6,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 344,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:09",
+            "timeRemaining": "03:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 202,
+            "details": {
+                "xCoord": -64,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482751,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 349,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:37",
+            "timeRemaining": "03:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 207,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 6,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:40",
+            "timeRemaining": "03:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 208,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 350,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:40",
+            "timeRemaining": "03:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 211,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8477919,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 156,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:51",
+            "timeRemaining": "03:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 212,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482470,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 354,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:04",
+            "timeRemaining": "02:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 213,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8481167,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 355,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:13",
+            "timeRemaining": "02:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 214,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8481167,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 391,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:17",
+            "timeRemaining": "02:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 216,
+            "details": {
+                "xCoord": -89,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8476456,
+                "hitteePlayerId": 8482866
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:20",
+            "timeRemaining": "02:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 217,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 357,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:20",
+            "timeRemaining": "02:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 220,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482209,
+                "winningPlayerId": 8478477,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:41",
+            "timeRemaining": "02:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 221,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 362,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:41",
+            "timeRemaining": "02:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 223,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482209,
+                "winningPlayerId": 8478477,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 392,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:50",
+            "timeRemaining": "02:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 224,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 9,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8482209,
+                "hitteePlayerId": 8484433
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:22",
+            "timeRemaining": "01:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 233,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 372,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:22",
+            "timeRemaining": "01:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 234,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8476905,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 384,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:29",
+            "timeRemaining": "01:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 235,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482858
+            }
+        },
+        {
+            "eventId": 393,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:43",
+            "timeRemaining": "01:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 237,
+            "details": {
+                "xCoord": 28,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8484180
+            }
+        },
+        {
+            "eventId": 380,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:59",
+            "timeRemaining": "01:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 239,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "cross-checking",
+                "duration": 2,
+                "committedByPlayerId": 8479985,
+                "drawnByPlayerId": 8484821,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 377,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:59",
+            "timeRemaining": "01:01",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 243,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 387,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:44",
+            "timeRemaining": "00:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 244,
+            "details": {
+                "xCoord": -48,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481789,
+                "shootingPlayerId": 8484768,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 388,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:55",
+            "timeRemaining": "00:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 245,
+            "details": {
+                "xCoord": -46,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484768,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 6,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 157,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:57",
+            "timeRemaining": "00:03",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 246,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 6,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 389,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 247,
+            "details": {
+                "xCoord": -88,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 6,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 501,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:59",
+            "timeRemaining": "00:01",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 248,
+            "details": {
+                "xCoord": -89,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 249
+        },
+        {
+            "eventId": 397,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 255
+        },
+        {
+            "eventId": 396,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 257,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8480028,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 453,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:22",
+            "timeRemaining": "19:38",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 258,
+            "details": {
+                "xCoord": 92,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482866
+            }
+        },
+        {
+            "eventId": 399,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 259,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8484768,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 452,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:45",
+            "timeRemaining": "19:15",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 262,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8476456,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 29,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:04",
+            "timeRemaining": "18:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 270,
+            "details": {
+                "reason": "puck-frozen"
+            }
+        },
+        {
+            "eventId": 462,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:04",
+            "timeRemaining": "18:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 272,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482074,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 273,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -19,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 481,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:24",
+            "timeRemaining": "18:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 274,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "playerId": 8482074,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:27",
+            "timeRemaining": "18:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 275,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 158,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:28",
+            "timeRemaining": "18:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 276,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484860,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 474,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 281,
+            "details": {
+                "xCoord": 85,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8482858,
+                "drawnByPlayerId": 8484860,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 470,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 285,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8478477,
+                "winningPlayerId": 8482679,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 478,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:57",
+            "timeRemaining": "18:03",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 286,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -17,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482751,
+                "shootingPlayerId": 8481068,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 484,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:36",
+            "timeRemaining": "17:24",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 291,
+            "details": {
+                "xCoord": 60,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8476905,
+                "shootingPlayerId": 8481068,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 485,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:44",
+            "timeRemaining": "17:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 292,
+            "details": {
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 31,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "17:13",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 293,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 486,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:47",
+            "timeRemaining": "17:13",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 296,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8483609,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 490,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:55",
+            "timeRemaining": "17:05",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 297,
+            "details": {
+                "xCoord": 30,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484150,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 492,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:14",
+            "timeRemaining": "16:46",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 299,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8482209,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8482074,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8484150,
+                "assist2PlayerTotal": 2,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8475831,
+                "awayScore": 1,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-kerins-scores-ppg-against-philipp-grubauer-6380017787112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-kerins-marque-un-but-en-a-n-contre-philipp-grubauer-6380018962112",
+                "highlightClip": 6380017787112,
+                "highlightClipFr": 6380018962112,
+                "discreteClip": 6380020419112,
+                "discreteClipFr": 6380018468112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010027/ev492.json"
+        },
+        {
+            "eventId": 493,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:14",
+            "timeRemaining": "16:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 303,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8484800,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 500,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 304,
+            "details": {
+                "xCoord": -90,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "failed-bank-attempt",
+                "shotType": "wrap-around",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 551,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 306,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479372,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 619,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:08",
+            "timeRemaining": "15:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 307,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8480860,
+                "hitteePlayerId": 8478975
+            }
+        },
+        {
+            "eventId": 628,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 308,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -15,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8479372
+            }
+        },
+        {
+            "eventId": 633,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:15",
+            "timeRemaining": "15:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 310,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478975,
+                "hitteePlayerId": 8482074
+            }
+        },
+        {
+            "eventId": 574,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:19",
+            "timeRemaining": "15:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 312,
+            "details": {
+                "xCoord": -7,
+                "yCoord": 41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479372
+            }
+        },
+        {
+            "eventId": 579,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:44",
+            "timeRemaining": "15:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 319,
+            "details": {
+                "xCoord": 8,
+                "yCoord": 21,
+                "zoneCode": "N",
+                "playerId": 8482470,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 560,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:54",
+            "timeRemaining": "15:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 320,
+            "details": {
+                "xCoord": 49,
+                "yCoord": 31,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8482470,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 503,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:32",
+            "timeRemaining": "14:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 327,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 32,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 331,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 576,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 332,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "hooking",
+                "duration": 2,
+                "committedByPlayerId": 8478975,
+                "drawnByPlayerId": 8480860,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 568,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 336,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482679,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 595,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:33",
+            "timeRemaining": "13:27",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 340,
+            "details": {
+                "xCoord": 36,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8481068
+            }
+        },
+        {
+            "eventId": 588,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:02",
+            "timeRemaining": "12:58",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 345,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8484150,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 662,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:04",
+            "timeRemaining": "12:56",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 346,
+            "details": {
+                "xCoord": 91,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 605,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:18",
+            "timeRemaining": "12:42",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 350,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482209
+            }
+        },
+        {
+            "eventId": 159,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:39",
+            "timeRemaining": "12:21",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 352,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 7,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 106,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:57",
+            "timeRemaining": "12:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 358,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -6,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 599,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:04",
+            "timeRemaining": "11:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": -38,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482866,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 604,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:30",
+            "timeRemaining": "11:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 364,
+            "details": {
+                "xCoord": 50,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484180,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 9,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 686,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:35",
+            "timeRemaining": "11:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 365,
+            "details": {
+                "xCoord": 28,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8484180,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 690,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:03",
+            "timeRemaining": "10:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 370,
+            "details": {
+                "xCoord": -39,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8484433,
+                "hitteePlayerId": 8482766
+            }
+        },
+        {
+            "eventId": 616,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:23",
+            "timeRemaining": "10:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 377,
+            "details": {
+                "xCoord": 68,
+                "yCoord": -32,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8482679,
+                "goalieInNetId": 8475831,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 9,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 621,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:42",
+            "timeRemaining": "10:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 381,
+            "details": {
+                "xCoord": 71,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8482679,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 622,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:49",
+            "timeRemaining": "10:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 384,
+            "details": {
+                "xCoord": -64,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 107,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:08",
+            "timeRemaining": "09:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 388,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482209,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 389,
+            "details": {
+                "reason": "puck-in-netting",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 629,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:10",
+            "timeRemaining": "09:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 392,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8476905,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 634,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:15",
+            "timeRemaining": "09:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 393,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 635,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:43",
+            "timeRemaining": "09:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 394,
+            "details": {
+                "xCoord": 46,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483609,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 638,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:00",
+            "timeRemaining": "09:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 397,
+            "details": {
+                "xCoord": 73,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479372,
+                "shootingPlayerId": 8482209,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 646,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:17",
+            "timeRemaining": "08:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 405,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484860,
+                "shootingPlayerId": 8478477,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 647,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:33",
+            "timeRemaining": "08:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 406,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -3,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482470,
+                "shootingPlayerId": 8484433,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 655,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:11",
+            "timeRemaining": "07:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 413,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8484860,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 10,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:20",
+            "timeRemaining": "07:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 415,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 658,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:20",
+            "timeRemaining": "07:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 418,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8484800,
+                "winningPlayerId": 8480028,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 672,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:34",
+            "timeRemaining": "07:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 419,
+            "details": {
+                "xCoord": -19,
+                "yCoord": -13,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484800
+            }
+        },
+        {
+            "eventId": 680,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 423,
+            "details": {
+                "xCoord": 28,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484800
+            }
+        },
+        {
+            "eventId": 160,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:04",
+            "timeRemaining": "06:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 426,
+            "details": {
+                "xCoord": 32,
+                "yCoord": 33,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482470,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 10,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 670,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:15",
+            "timeRemaining": "06:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 429,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484821,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 10,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 671,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:28",
+            "timeRemaining": "06:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 430,
+            "details": {
+                "xCoord": 82,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "blockingPlayerId": 8484180,
+                "shootingPlayerId": 8484821,
+                "eventOwnerTeamId": 20,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:34",
+            "timeRemaining": "06:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 431,
+            "details": {
+                "xCoord": 22,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8481167,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 677,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:54",
+            "timeRemaining": "06:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 436,
+            "details": {
+                "xCoord": -78,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482874,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 678,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:01",
+            "timeRemaining": "05:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 437,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8481167,
+                "shootingPlayerId": 8479372,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:11",
+            "timeRemaining": "05:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 440,
+            "details": {
+                "reason": "puck-in-benches",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 681,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:11",
+            "timeRemaining": "05:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 443,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477993,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:19",
+            "timeRemaining": "05:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 444,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 687,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:19",
+            "timeRemaining": "05:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 446,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8476905,
+                "winningPlayerId": 8477993,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 759,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:38",
+            "timeRemaining": "05:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 448,
+            "details": {
+                "xCoord": 22,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8484768
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:17",
+            "timeRemaining": "04:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 457,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 7,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482874,
+                "shootingPlayerId": 8483010,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 702,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:29",
+            "timeRemaining": "04:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 458,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 5,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482165,
+                "shootingPlayerId": 8484433,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 721,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:47",
+            "timeRemaining": "04:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 464,
+            "details": {
+                "xCoord": -41,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484800
+            }
+        },
+        {
+            "eventId": 709,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:03",
+            "timeRemaining": "03:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 466,
+            "details": {
+                "xCoord": 75,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482751,
+                "shootingPlayerId": 8482470,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 760,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:08",
+            "timeRemaining": "03:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 467,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8476456,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 710,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:12",
+            "timeRemaining": "03:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 468,
+            "details": {
+                "xCoord": 66,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484433,
+                "shootingPlayerId": 8482470,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 728,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:28",
+            "timeRemaining": "03:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 469,
+            "details": {
+                "xCoord": 3,
+                "yCoord": 39,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8476456
+            }
+        },
+        {
+            "eventId": 718,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:49",
+            "timeRemaining": "03:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 478,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484821,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 11,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 720,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:55",
+            "timeRemaining": "03:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 479,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484821,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 11,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 722,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:02",
+            "timeRemaining": "02:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 480,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482858,
+                "shootingPlayerId": 8484768,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 726,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:41",
+            "timeRemaining": "02:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 484,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482874,
+                "shootingPlayerId": 8480860,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 737,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:54",
+            "timeRemaining": "02:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 489,
+            "details": {
+                "xCoord": -2,
+                "yCoord": -37,
+                "zoneCode": "N",
+                "playerId": 8477919,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 761,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:00",
+            "timeRemaining": "02:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 490,
+            "details": {
+                "xCoord": -96,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483449,
+                "hitteePlayerId": 8484768
+            }
+        },
+        {
+            "eventId": 762,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:30",
+            "timeRemaining": "01:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": 95,
+                "yCoord": -21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479372,
+                "hitteePlayerId": 8482074
+            }
+        },
+        {
+            "eventId": 742,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:12",
+            "timeRemaining": "00:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 501,
+            "details": {
+                "xCoord": 59,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481167,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 11,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:32",
+            "timeRemaining": "00:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 503,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 745,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:32",
+            "timeRemaining": "00:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 505,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 749,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:49",
+            "timeRemaining": "00:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 508,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484217,
+                "goalieInNetId": 8481692,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:51",
+            "timeRemaining": "00:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 510,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 751,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:51",
+            "timeRemaining": "00:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 513,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 514,
+            "details": {
+                "reason": "puck-in-crowd"
+            }
+        },
+        {
+            "eventId": 755,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:58",
+            "timeRemaining": "00:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 515,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8478975,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 516
+        },
+        {
+            "eventId": 766,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 522
+        },
+        {
+            "eventId": 765,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 524,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8484800,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:09",
+            "timeRemaining": "19:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 525,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8480860
+            }
+        },
+        {
+            "eventId": 768,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:18",
+            "timeRemaining": "19:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 526,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8484768,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 769,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 527,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -25,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8482679,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8480028,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8476456,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 20,
+                "goalieInNetId": 8476899,
+                "awayScore": 1,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-coronato-scores-goal-against-matt-murray-6380021062112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-coronato-marque-un-but-contre-matt-murray-6380021350112",
+                "highlightClip": 6380021062112,
+                "highlightClipFr": 6380021350112,
+                "discreteClip": 6380021747112,
+                "discreteClipFr": 6380021058112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010027/ev769.json"
+        },
+        {
+            "eventId": 770,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 530,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8482209,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 531,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 774,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 534,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8478477,
+                "winningPlayerId": 8477993,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 824,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:20",
+            "timeRemaining": "18:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 535,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -32,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8482470
+            }
+        },
+        {
+            "eventId": 779,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:23",
+            "timeRemaining": "18:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 536,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "high-and-wide-left",
+                "shotType": "snap",
+                "shootingPlayerId": 8483609,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 829,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:25",
+            "timeRemaining": "18:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 537,
+            "details": {
+                "xCoord": -70,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8482470
+            }
+        },
+        {
+            "eventId": 803,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:49",
+            "timeRemaining": "18:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 541,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8482874
+            }
+        },
+        {
+            "eventId": 839,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:11",
+            "timeRemaining": "17:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 546,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477919,
+                "hitteePlayerId": 8484768
+            }
+        },
+        {
+            "eventId": 862,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 547,
+            "details": {
+                "xCoord": 92,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8484768,
+                "hitteePlayerId": 8484219
+            }
+        },
+        {
+            "eventId": 812,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:21",
+            "timeRemaining": "17:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": 72,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477919
+            }
+        },
+        {
+            "eventId": 813,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:37",
+            "timeRemaining": "17:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": -25,
+                "yCoord": 21,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484219
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:51",
+            "timeRemaining": "17:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 558,
+            "details": {
+                "xCoord": 55,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478975,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 559,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 800,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 561,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8478477,
+                "winningPlayerId": 8484821,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 830,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:14",
+            "timeRemaining": "16:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 562,
+            "details": {
+                "xCoord": -33,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "playerId": 8482165
+            }
+        },
+        {
+            "eventId": 162,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:36",
+            "timeRemaining": "16:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 566,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 12,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 567,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 808,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:37",
+            "timeRemaining": "16:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 570,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482209,
+                "winningPlayerId": 8483010,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 876,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:51",
+            "timeRemaining": "16:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 571,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8482470
+            }
+        },
+        {
+            "eventId": 108,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:53",
+            "timeRemaining": "16:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 572,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 504,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:54",
+            "timeRemaining": "16:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 573,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "bat",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 819,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:18",
+            "timeRemaining": "15:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 580,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -33,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484860,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 13,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:33",
+            "timeRemaining": "15:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 581,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 821,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:33",
+            "timeRemaining": "15:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 584,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8482074,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 831,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:44",
+            "timeRemaining": "15:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 585,
+            "details": {
+                "xCoord": -77,
+                "yCoord": 20,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484217,
+                "shootingPlayerId": 8477993,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 832,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:47",
+            "timeRemaining": "15:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 586,
+            "details": {
+                "xCoord": -73,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477993,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 49,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:12",
+            "timeRemaining": "14:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 588,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 834,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:12",
+            "timeRemaining": "14:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 591,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480028,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 838,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:16",
+            "timeRemaining": "14:44",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 592,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "reason": "hit-left-post",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 847,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:49",
+            "timeRemaining": "14:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 600,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8481167,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 848,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:50",
+            "timeRemaining": "14:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 601,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 869,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:11",
+            "timeRemaining": "13:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 606,
+            "details": {
+                "xCoord": 20,
+                "yCoord": -26,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "playerId": 8481167
+            }
+        },
+        {
+            "eventId": 908,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:13",
+            "timeRemaining": "13:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 607,
+            "details": {
+                "xCoord": 41,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8481167,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 918,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:22",
+            "timeRemaining": "13:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 609,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 35,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8484821
+            }
+        },
+        {
+            "eventId": 856,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:43",
+            "timeRemaining": "13:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 613,
+            "details": {
+                "xCoord": 81,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482751,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 50,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:19",
+            "timeRemaining": "12:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 621,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 401,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:19",
+            "timeRemaining": "12:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 622,
+            "details": {
+                "reason": "player-equipment",
+                "secondaryReason": "player-equipment"
+            }
+        },
+        {
+            "eventId": 866,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:19",
+            "timeRemaining": "12:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 624,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482209,
+                "winningPlayerId": 8483010,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:53",
+            "timeRemaining": "12:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 627,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 872,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:53",
+            "timeRemaining": "12:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 630,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8477993,
+                "xCoord": 20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 938,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:18",
+            "timeRemaining": "11:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 631,
+            "details": {
+                "xCoord": -39,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 882,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:24",
+            "timeRemaining": "11:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 632,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477919
+            }
+        },
+        {
+            "eventId": 888,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:28",
+            "timeRemaining": "11:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 633,
+            "details": {
+                "xCoord": 48,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "playerId": 8477993
+            }
+        },
+        {
+            "eventId": 878,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:42",
+            "timeRemaining": "11:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": 76,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482470,
+                "shootingPlayerId": 8484217,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 884,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:49",
+            "timeRemaining": "11:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 637,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -39,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "holding",
+                "duration": 2,
+                "committedByPlayerId": 8482470,
+                "drawnByPlayerId": 8478477,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 879,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:49",
+            "timeRemaining": "11:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 641,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 890,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:02",
+            "timeRemaining": "10:58",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 643,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8484180,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 960,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:03",
+            "timeRemaining": "10:57",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 644,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8484180,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 900,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:53",
+            "timeRemaining": "10:07",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 653,
+            "details": {
+                "xCoord": 61,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483449,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 403,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:55",
+            "timeRemaining": "10:05",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 654,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 901,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:55",
+            "timeRemaining": "10:05",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 656,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8482751,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:58",
+            "timeRemaining": "10:02",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 657,
+            "details": {
+                "xCoord": 33,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 404,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:01",
+            "timeRemaining": "09:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 658,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 905,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:01",
+            "timeRemaining": "09:59",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 660,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8482751,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 919,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:33",
+            "timeRemaining": "09:27",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 661,
+            "details": {
+                "xCoord": 25,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8484219
+            }
+        },
+        {
+            "eventId": 405,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:02",
+            "timeRemaining": "08:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 671,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 920,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:02",
+            "timeRemaining": "08:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 673,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482209,
+                "winningPlayerId": 8478477,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 973,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:54",
+            "timeRemaining": "08:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 682,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478975,
+                "hitteePlayerId": 8482470
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:24",
+            "timeRemaining": "07:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 685,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 934,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:24",
+            "timeRemaining": "07:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 688,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8478477,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 983,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:31",
+            "timeRemaining": "07:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 689,
+            "details": {
+                "xCoord": 94,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8482165
+            }
+        },
+        {
+            "eventId": 407,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:35",
+            "timeRemaining": "07:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 690,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 939,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:35",
+            "timeRemaining": "07:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 691,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8478477,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 951,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:46",
+            "timeRemaining": "07:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 692,
+            "details": {
+                "xCoord": 36,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483449
+            }
+        },
+        {
+            "eventId": 941,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 693,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8484180,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 15,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 164,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:29",
+            "timeRemaining": "06:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 701,
+            "details": {
+                "xCoord": 4,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8476456,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 15,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 408,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:35",
+            "timeRemaining": "06:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 702,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 949,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:35",
+            "timeRemaining": "06:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 703,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8477919,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:44",
+            "timeRemaining": "06:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 704,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 19,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484219,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 409,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:46",
+            "timeRemaining": "06:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 705,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 953,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:46",
+            "timeRemaining": "06:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 708,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 961,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:48",
+            "timeRemaining": "06:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 709,
+            "details": {
+                "xCoord": 33,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 165,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:52",
+            "timeRemaining": "06:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 710,
+            "details": {
+                "xCoord": 72,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484800,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 962,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:02",
+            "timeRemaining": "05:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 711,
+            "details": {
+                "xCoord": 34,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 410,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:04",
+            "timeRemaining": "05:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 712,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 963,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:04",
+            "timeRemaining": "05:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 715,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8484800,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 967,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:07",
+            "timeRemaining": "05:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 716,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8485465,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 19,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 411,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 717,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 968,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 719,
+            "details": {
+                "eventOwnerTeamId": 20,
+                "losingPlayerId": 8478975,
+                "winningPlayerId": 8480028,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 979,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:15",
+            "timeRemaining": "04:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 727,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482074,
+                "shootingPlayerId": 8483449,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 412,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:17",
+            "timeRemaining": "04:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 728,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 980,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:17",
+            "timeRemaining": "04:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 730,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8477993,
+                "winningPlayerId": 8478477,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1022,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:19",
+            "timeRemaining": "04:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 731,
+            "details": {
+                "xCoord": 56,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8483609,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 1037,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:41",
+            "timeRemaining": "03:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 744,
+            "details": {
+                "xCoord": 0,
+                "yCoord": -38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 20,
+                "hittingPlayerId": 8484860,
+                "hitteePlayerId": 8480009
+            }
+        },
+        {
+            "eventId": 1002,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:06",
+            "timeRemaining": "02:54",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 750,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482766,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1007,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:21",
+            "timeRemaining": "02:39",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 751,
+            "details": {
+                "xCoord": -3,
+                "yCoord": -25,
+                "zoneCode": "N",
+                "playerId": 8484180,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 1003,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:26",
+            "timeRemaining": "02:34",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 752,
+            "details": {
+                "xCoord": -57,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "scoringPlayerId": 8484821,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8484180,
+                "assist1PlayerTotal": 1,
+                "eventOwnerTeamId": 20,
+                "awayScore": 1,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-cgy-morton-scores-empty-net-goal-6380022254112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-cgy-morton-cgy-marque-un-but-dans-un-filet-desert-6380021587112",
+                "highlightClip": 6380022254112,
+                "highlightClipFr": 6380021587112,
+                "discreteClip": 6380020398112,
+                "discreteClipFr": 6380022253112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010027/ev1003.json"
+        },
+        {
+            "eventId": 1004,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:26",
+            "timeRemaining": "02:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 755,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482679,
+                "winningPlayerId": 8478477,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1017,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:31",
+            "timeRemaining": "01:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 763,
+            "details": {
+                "xCoord": -70,
+                "yCoord": -13,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8482074,
+                "eventOwnerTeamId": 20,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 109,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:36",
+            "timeRemaining": "01:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 764,
+            "details": {
+                "xCoord": -69,
+                "yCoord": 2,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482074,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 413,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 765,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 414,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 766,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8483609,
+                "drawnByPlayerId": 8482866,
+                "servedByPlayerId": 8484860,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 418,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 770,
+            "details": {
+                "xCoord": -85,
+                "yCoord": 0,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8483609,
+                "drawnByPlayerId": 8482866,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 422,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 772,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8482866,
+                "drawnByPlayerId": 8483609,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 434,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 774,
+            "details": {
+                "xCoord": -86,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8483609,
+                "eventOwnerTeamId": 20
+            }
+        },
+        {
+            "eventId": 425,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 776,
+            "details": {
+                "xCoord": -85,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "typeCode": "MIS",
+                "descKey": "misconduct",
+                "duration": 10,
+                "committedByPlayerId": 8482866,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1019,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 778,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8484821,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 1027,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:00",
+            "timeRemaining": "01:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 779,
+            "details": {
+                "xCoord": -60,
+                "yCoord": 8,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484180,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 1039,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:00",
+            "timeRemaining": "01:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 780,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -12,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8484821
+            }
+        },
+        {
+            "eventId": 1040,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:11",
+            "timeRemaining": "00:49",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 781,
+            "details": {
+                "xCoord": -81,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8478975,
+                "hitteePlayerId": 8484821
+            }
+        },
+        {
+            "eventId": 110,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:12",
+            "timeRemaining": "00:48",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 782,
+            "details": {
+                "xCoord": -31,
+                "yCoord": 23,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8481167,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 20,
+                "awaySOG": 19,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 166,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:39",
+            "timeRemaining": "00:21",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 789,
+            "details": {
+                "reason": "hand-pass"
+            }
+        },
+        {
+            "eventId": 1034,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:39",
+            "timeRemaining": "00:21",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 791,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480028,
+                "winningPlayerId": 8482751,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 428,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 792
+        },
+        {
+            "eventId": 432,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 796
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8475831.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8476456,
+            "firstName": {
+                "default": "Jonathan"
+            },
+            "lastName": {
+                "default": "Huberdeau"
+            },
+            "sweaterNumber": 10,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8476456.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476899,
+            "firstName": {
+                "default": "Matt"
+            },
+            "lastName": {
+                "default": "Murray"
+            },
+            "sweaterNumber": 30,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8476899.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476905,
+            "firstName": {
+                "default": "Chandler"
+            },
+            "lastName": {
+                "default": "Stephenson"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8476905.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477919,
+            "firstName": {
+                "default": "Frederick"
+            },
+            "lastName": {
+                "default": "Gaudreau"
+            },
+            "sweaterNumber": 89,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8477919.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8477993,
+            "firstName": {
+                "default": "Justin"
+            },
+            "lastName": {
+                "default": "Kirkland"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8477993.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478477,
+            "firstName": {
+                "default": "Mitchell"
+            },
+            "lastName": {
+                "default": "Stephens"
+            },
+            "sweaterNumber": 67,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8478477.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478975,
+            "firstName": {
+                "default": "Mason"
+            },
+            "lastName": {
+                "default": "Marchment"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8478975.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479372,
+            "firstName": {
+                "default": "Joshua",
+                "cs": "Josh",
+                "de": "Josh",
+                "es": "Josh",
+                "fi": "Josh",
+                "sk": "Josh",
+                "sv": "Josh"
+            },
+            "lastName": {
+                "default": "Mahura"
+            },
+            "sweaterNumber": 28,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8479372.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479985,
+            "firstName": {
+                "default": "Cale"
+            },
+            "lastName": {
+                "default": "Fleury"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8479985.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8480009.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8480028,
+            "firstName": {
+                "default": "Morgan"
+            },
+            "lastName": {
+                "default": "Frost"
+            },
+            "sweaterNumber": 16,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8480028.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8480860,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Bahl"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8480860.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481068,
+            "firstName": {
+                "default": "Yegor",
+                "cs": "Jegor",
+                "fi": "Jahor",
+                "sk": "Jegor"
+            },
+            "lastName": {
+                "default": "Sharangovich",
+                "cs": "\u0160arangovi\u010d",
+                "fi": "Sharanhovitsh",
+                "sk": "\u0160arangovi\u010d"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8481068.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481167,
+            "firstName": {
+                "default": "Brayden"
+            },
+            "lastName": {
+                "default": "Pachal"
+            },
+            "sweaterNumber": 94,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8481167.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8481692,
+            "firstName": {
+                "default": "Dustin"
+            },
+            "lastName": {
+                "default": "Wolf"
+            },
+            "sweaterNumber": 32,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8481692.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8481789.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482074,
+            "firstName": {
+                "default": "Connor"
+            },
+            "lastName": {
+                "default": "Zary"
+            },
+            "sweaterNumber": 47,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482074.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482165,
+            "firstName": {
+                "default": "Yan"
+            },
+            "lastName": {
+                "default": "Kuznetsov"
+            },
+            "sweaterNumber": 37,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482165.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482209,
+            "firstName": {
+                "default": "Rory"
+            },
+            "lastName": {
+                "default": "Kerins"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482209.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482470,
+            "firstName": {
+                "default": "Ilya"
+            },
+            "lastName": {
+                "default": "Solovyov"
+            },
+            "sweaterNumber": 98,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482470.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482679,
+            "firstName": {
+                "default": "Matt"
+            },
+            "lastName": {
+                "default": "Coronato"
+            },
+            "sweaterNumber": 27,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482679.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482751,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Winterton"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482751.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8482766,
+            "firstName": {
+                "default": "William"
+            },
+            "lastName": {
+                "default": "Stromgren"
+            },
+            "sweaterNumber": 65,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8482766.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482866,
+            "firstName": {
+                "default": "Ville"
+            },
+            "lastName": {
+                "default": "Ottavainen"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482866.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482874,
+            "firstName": {
+                "default": "Jacob"
+            },
+            "lastName": {
+                "default": "Melanson"
+            },
+            "sweaterNumber": 63,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482874.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483010,
+            "firstName": {
+                "default": "Jon-Randall"
+            },
+            "lastName": {
+                "default": "Avon"
+            },
+            "sweaterNumber": 16,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483010.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483449,
+            "firstName": {
+                "default": "David"
+            },
+            "lastName": {
+                "default": "Goyette"
+            },
+            "sweaterNumber": 88,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483449.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8483609,
+            "firstName": {
+                "default": "Adam"
+            },
+            "lastName": {
+                "default": "Klapka"
+            },
+            "sweaterNumber": 43,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8483609.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8484150,
+            "firstName": {
+                "default": "Hunter"
+            },
+            "lastName": {
+                "default": "Brzustewicz"
+            },
+            "sweaterNumber": 48,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8484150.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8484180,
+            "firstName": {
+                "default": "Samuel"
+            },
+            "lastName": {
+                "default": "Honzek"
+            },
+            "sweaterNumber": 29,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8484180.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484217,
+            "firstName": {
+                "default": "Caden"
+            },
+            "lastName": {
+                "default": "Price"
+            },
+            "sweaterNumber": 48,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484217.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484219,
+            "firstName": {
+                "default": "Carson"
+            },
+            "lastName": {
+                "default": "Rehkopf"
+            },
+            "sweaterNumber": 74,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484219.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484433,
+            "firstName": {
+                "default": "Kaden"
+            },
+            "lastName": {
+                "default": "Hammell"
+            },
+            "sweaterNumber": 47,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484433.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8484768,
+            "firstName": {
+                "default": "Zayne"
+            },
+            "lastName": {
+                "default": "Parekh"
+            },
+            "sweaterNumber": 89,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8484768.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484800,
+            "firstName": {
+                "default": "Berkly"
+            },
+            "lastName": {
+                "default": "Catton"
+            },
+            "sweaterNumber": 77,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484800.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8484821,
+            "firstName": {
+                "default": "Sam"
+            },
+            "lastName": {
+                "default": "Morton"
+            },
+            "sweaterNumber": 45,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8484821.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8484860,
+            "firstName": {
+                "default": "Matvei"
+            },
+            "lastName": {
+                "default": "Gridin"
+            },
+            "sweaterNumber": 51,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8484860.png"
+        },
+        {
+            "teamId": 20,
+            "playerId": 8485465,
+            "firstName": {
+                "default": "Owen"
+            },
+            "lastName": {
+                "default": "Say"
+            },
+            "sweaterNumber": 80,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/CGY/8485465.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -104,3 +104,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 ### 2025-26 Preseason
 
 - [PRESEASON GAME #1: Vancouver Canucks vs Seattle Kraken - Seattle wins 5-3](./2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json)
+- [PRESEASON GAME #2: Seattle Kraken vs Calgary Flames - Seattle loses 4-1](./2025-26/preseason/20250923-SEA-vs-CGY-2025010027.json)


### PR DESCRIPTION
# Description

Added Seattle Kraken vs Calgary Flames preseason game data from September 23rd, 2025 to the repository. This includes:

- Downloaded play-by-play data from the NHL API
- Updated the NHL data README.md with the new game entry
- Final score: Calgary Flames 4, Seattle Kraken 1

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG