### PR TITLE
feat: add 2025-09-26 Seattle Kraken @ Vancouver Canucks preseason game data

### DIFF
--- a/data/NHL - National Hockey League/2025-26/preseason/20250926-SEA-vs-VAN-2025010043.json
+++ b/data/NHL - National Hockey League/2025-26/preseason/20250926-SEA-vs-VAN-2025010043.json
@@ -1,0 +1,7281 @@
+{
+    "id": 2025010043,
+    "season": 20252026,
+    "gameType": 1,
+    "limitedScoring": false,
+    "gameDate": "2025-09-26",
+    "venue": {
+        "default": "Rogers Arena"
+    },
+    "venueLocation": {
+        "default": "Vancouver"
+    },
+    "startTimeUTC": "2025-09-27T02:00:00Z",
+    "easternUTCOffset": "-04:00",
+    "venueUTCOffset": "-07:00",
+    "tvBroadcasts": [
+        {
+            "id": 290,
+            "market": "N",
+            "countryCode": "CA",
+            "network": "SNP",
+            "sequenceNumber": 33
+        },
+        {
+            "id": 324,
+            "market": "N",
+            "countryCode": "US",
+            "network": "NHLN",
+            "sequenceNumber": 35
+        },
+        {
+            "id": 554,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KHN",
+            "sequenceNumber": 339
+        },
+        {
+            "id": 388,
+            "market": "A",
+            "countryCode": "US",
+            "network": "KONG",
+            "sequenceNumber": 654
+        }
+    ],
+    "gameState": "FINAL",
+    "gameScheduleState": "OK",
+    "periodDescriptor": {
+        "number": 3,
+        "periodType": "REG",
+        "maxRegulationPeriods": 3
+    },
+    "awayTeam": {
+        "id": 55,
+        "commonName": {
+            "default": "Kraken"
+        },
+        "abbrev": "SEA",
+        "score": 2,
+        "sog": 23,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/SEA_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/SEA_dark.svg",
+        "placeName": {
+            "default": "Seattle"
+        },
+        "placeNameWithPreposition": {
+            "default": "Seattle",
+            "fr": "de Seattle"
+        }
+    },
+    "homeTeam": {
+        "id": 23,
+        "commonName": {
+            "default": "Canucks"
+        },
+        "abbrev": "VAN",
+        "score": 4,
+        "sog": 37,
+        "logo": "https://assets.nhle.com/logos/nhl/svg/VAN_light.svg",
+        "darkLogo": "https://assets.nhle.com/logos/nhl/svg/VAN_dark.svg",
+        "placeName": {
+            "default": "Vancouver"
+        },
+        "placeNameWithPreposition": {
+            "default": "Vancouver",
+            "fr": "de Vancouver"
+        }
+    },
+    "shootoutInUse": true,
+    "otInUse": true,
+    "clock": {
+        "timeRemaining": "00:00",
+        "secondsRemaining": 0,
+        "running": false,
+        "inIntermission": false
+    },
+    "displayPeriod": 1,
+    "maxPeriods": 5,
+    "gameOutcome": {
+        "lastPeriodType": "REG"
+    },
+    "plays": [
+        {
+            "eventId": 54,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 10
+        },
+        {
+            "eventId": 53,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 11,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480012,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 66,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:14",
+            "timeRemaining": "19:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 12,
+            "details": {
+                "xCoord": -84,
+                "yCoord": 27,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477919
+            }
+        },
+        {
+            "eventId": 67,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:17",
+            "timeRemaining": "19:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 13,
+            "details": {
+                "xCoord": -42,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8479425
+            }
+        },
+        {
+            "eventId": 55,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:21",
+            "timeRemaining": "19:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 15,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -14,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484800,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 1,
+                "homeSOG": 0
+            }
+        },
+        {
+            "eventId": 69,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:27",
+            "timeRemaining": "19:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 16,
+            "details": {
+                "xCoord": 98,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8477919,
+                "hitteePlayerId": 8480012
+            }
+        },
+        {
+            "eventId": 57,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:33",
+            "timeRemaining": "19:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 17,
+            "details": {
+                "xCoord": 40,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 78,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:07",
+            "timeRemaining": "18:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 27,
+            "details": {
+                "xCoord": -59,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 80,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:13",
+            "timeRemaining": "18:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 28,
+            "details": {
+                "xCoord": 95,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484240,
+                "hitteePlayerId": 8482874
+            }
+        },
+        {
+            "eventId": 86,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:21",
+            "timeRemaining": "18:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 29,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 6,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483678,
+                "hitteePlayerId": 8481789
+            }
+        },
+        {
+            "eventId": 92,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:26",
+            "timeRemaining": "18:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 31,
+            "details": {
+                "xCoord": -7,
+                "yCoord": 38,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8483476
+            }
+        },
+        {
+            "eventId": 8,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 34,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 71,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 37,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8476927,
+                "xCoord": -20,
+                "yCoord": 22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 99,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:34",
+            "timeRemaining": "18:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 38,
+            "details": {
+                "xCoord": -4,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8483467
+            }
+        },
+        {
+            "eventId": 9,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:43",
+            "timeRemaining": "18:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 39,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 77,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:43",
+            "timeRemaining": "18:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 40,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484168,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 117,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:10",
+            "timeRemaining": "17:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 41,
+            "details": {
+                "xCoord": 55,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 87,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:13",
+            "timeRemaining": "17:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 42,
+            "details": {
+                "xCoord": 87,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483497
+            }
+        },
+        {
+            "eventId": 701,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 43,
+            "details": {
+                "xCoord": 74,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "scoringPlayerId": 8483497,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8484162,
+                "assist1PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480947,
+                "awayScore": 1,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-nyman-scores-goal-against-kevin-lankinen-6380170076112",
+                "highlightClip": 6380170076112
+            }
+        },
+        {
+            "eventId": 82,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 46,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8483012,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 13,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 47,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 88,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:29",
+            "timeRemaining": "17:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 50,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8484408,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 14,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:36",
+            "timeRemaining": "17:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 51,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 93,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:36",
+            "timeRemaining": "17:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 52,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8482691,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 102,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:07",
+            "timeRemaining": "16:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 59,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 1,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 106,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:44",
+            "timeRemaining": "16:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 63,
+            "details": {
+                "xCoord": -75,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 108,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:53",
+            "timeRemaining": "16:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 66,
+            "details": {
+                "xCoord": 79,
+                "yCoord": 16,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 2,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 121,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:10",
+            "timeRemaining": "15:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 74,
+            "details": {
+                "xCoord": -30,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8483476
+            }
+        },
+        {
+            "eventId": 118,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:36",
+            "timeRemaining": "15:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 75,
+            "details": {
+                "xCoord": 38,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484162,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 3,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 15,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 76,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 119,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:39",
+            "timeRemaining": "15:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 79,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8483497,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 251,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:09",
+            "timeRemaining": "14:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 80,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484168,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 4,
+                "homeSOG": 1
+            }
+        },
+        {
+            "eventId": 16,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 81,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 124,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:10",
+            "timeRemaining": "14:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 84,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8482691,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 146,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:18",
+            "timeRemaining": "14:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 85,
+            "details": {
+                "xCoord": -22,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8484408
+            }
+        },
+        {
+            "eventId": 133,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:54",
+            "timeRemaining": "14:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 90,
+            "details": {
+                "xCoord": 84,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "blockingPlayerId": 8478477,
+                "shootingPlayerId": 8479324,
+                "eventOwnerTeamId": 55,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 17,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:34",
+            "timeRemaining": "13:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 97,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 141,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:34",
+            "timeRemaining": "13:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 99,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8483570,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 301,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:36",
+            "timeRemaining": "13:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 100,
+            "details": {
+                "xCoord": 90,
+                "yCoord": -20,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 4,
+                "homeSOG": 2
+            }
+        },
+        {
+            "eventId": 145,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:36",
+            "timeRemaining": "13:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 101,
+            "details": {
+                "xCoord": 31,
+                "yCoord": 17,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 205,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 105,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -37,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480012,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 150,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:11",
+            "timeRemaining": "12:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 106,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 37,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484240,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 4,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 18,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:13",
+            "timeRemaining": "12:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 107,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 201,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:13",
+            "timeRemaining": "12:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 110,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480012,
+                "winningPlayerId": 8483570,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 206,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:41",
+            "timeRemaining": "12:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 111,
+            "details": {
+                "xCoord": -63,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479324,
+                "shootingPlayerId": 8478444,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 19,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:12",
+            "timeRemaining": "11:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 121,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 216,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:12",
+            "timeRemaining": "11:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 122,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8485385,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 219,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:51",
+            "timeRemaining": "11:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 123,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483684,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 232,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:20",
+            "timeRemaining": "10:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 130,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 29,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8476927
+            }
+        },
+        {
+            "eventId": 252,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:23",
+            "timeRemaining": "10:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 131,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8477919,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 5,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 20,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 132,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 226,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 133,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 245,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:42",
+            "timeRemaining": "10:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 134,
+            "details": {
+                "xCoord": 38,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 366,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:47",
+            "timeRemaining": "09:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 150,
+            "details": {
+                "xCoord": -68,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8480012
+            }
+        },
+        {
+            "eventId": 244,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:58",
+            "timeRemaining": "09:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 151,
+            "details": {
+                "xCoord": -70,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480012,
+                "shootingPlayerId": 8478444,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 382,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:39",
+            "timeRemaining": "08:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 159,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -25,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484240,
+                "hitteePlayerId": 8482874
+            }
+        },
+        {
+            "eventId": 362,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:18",
+            "timeRemaining": "07:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 169,
+            "details": {
+                "xCoord": 70,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "snap",
+                "shootingPlayerId": 8484168,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 374,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:25",
+            "timeRemaining": "07:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 171,
+            "details": {
+                "xCoord": -34,
+                "yCoord": -34,
+                "zoneCode": "D",
+                "playerId": 8483684,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 379,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:33",
+            "timeRemaining": "07:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 173,
+            "details": {
+                "xCoord": 13,
+                "yCoord": 4,
+                "zoneCode": "N",
+                "playerId": 8480058,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 253,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:03",
+            "timeRemaining": "06:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 182,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479324,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 6,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 376,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:09",
+            "timeRemaining": "06:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 183,
+            "details": {
+                "xCoord": 36,
+                "yCoord": -36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 7,
+                "homeSOG": 3
+            }
+        },
+        {
+            "eventId": 21,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:11",
+            "timeRemaining": "06:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 184,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 377,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:11",
+            "timeRemaining": "06:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 187,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 392,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:34",
+            "timeRemaining": "05:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 197,
+            "details": {
+                "xCoord": -61,
+                "yCoord": -29,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480012,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 7,
+                "homeSOG": 4
+            }
+        },
+        {
+            "eventId": 397,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:37",
+            "timeRemaining": "05:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 198,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8480012
+            }
+        },
+        {
+            "eventId": 399,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:48",
+            "timeRemaining": "05:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 200,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483570,
+                "hitteePlayerId": 8478498
+            }
+        },
+        {
+            "eventId": 22,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 201,
+            "details": {
+                "reason": "offside",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 394,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 204,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8475169,
+                "xCoord": -20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 406,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:00",
+            "timeRemaining": "05:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 205,
+            "details": {
+                "xCoord": -99,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "playerId": 8485385,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 400,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:02",
+            "timeRemaining": "04:58",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 206,
+            "details": {
+                "xCoord": -68,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 7,
+                "homeSOG": 5
+            }
+        },
+        {
+            "eventId": 407,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:14",
+            "timeRemaining": "04:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 207,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -30,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479324
+            }
+        },
+        {
+            "eventId": 408,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:21",
+            "timeRemaining": "04:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 208,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 401,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:26",
+            "timeRemaining": "04:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 209,
+            "details": {
+                "xCoord": -37,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475169,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 7,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 23,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 210,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 402,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:28",
+            "timeRemaining": "04:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 213,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8482691,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 421,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:44",
+            "timeRemaining": "04:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 214,
+            "details": {
+                "xCoord": -84,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8482918
+            }
+        },
+        {
+            "eventId": 428,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:19",
+            "timeRemaining": "03:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 220,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480833,
+                "hitteePlayerId": 8484162
+            }
+        },
+        {
+            "eventId": 417,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:22",
+            "timeRemaining": "03:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 221,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "tripping",
+                "duration": 2,
+                "committedByPlayerId": 8480833,
+                "drawnByPlayerId": 8483684,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 414,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:22",
+            "timeRemaining": "03:38",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 225,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 447,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:33",
+            "timeRemaining": "02:27",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 234,
+            "details": {
+                "xCoord": 44,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483678,
+                "hitteePlayerId": 8483012
+            }
+        },
+        {
+            "eventId": 431,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:49",
+            "timeRemaining": "02:11",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 235,
+            "details": {
+                "xCoord": 51,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484408,
+                "shootingPlayerId": 8482858,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 24,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:52",
+            "timeRemaining": "02:08",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 236,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 432,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:52",
+            "timeRemaining": "02:08",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 238,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480012,
+                "winningPlayerId": 8484168,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 436,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:09",
+            "timeRemaining": "01:51",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 239,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 8,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 510,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:33",
+            "timeRemaining": "01:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 247,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483570,
+                "hitteePlayerId": 8479425
+            }
+        },
+        {
+            "eventId": 511,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:37",
+            "timeRemaining": "01:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 248,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -37,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8478444,
+                "hitteePlayerId": 8483570
+            }
+        },
+        {
+            "eventId": 444,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:40",
+            "timeRemaining": "01:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 249,
+            "details": {
+                "xCoord": 31,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 9,
+                "homeSOG": 6
+            }
+        },
+        {
+            "eventId": 502,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:23",
+            "timeRemaining": "00:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 256,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 9,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 25,
+            "periodDescriptor": {
+                "number": 1,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 263
+        },
+        {
+            "eventId": 515,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 270
+        },
+        {
+            "eventId": 514,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 271,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480012,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 516,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:26",
+            "timeRemaining": "19:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 272,
+            "details": {
+                "xCoord": -82,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 10,
+                "homeSOG": 7
+            }
+        },
+        {
+            "eventId": 30,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 273,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 517,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:29",
+            "timeRemaining": "19:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 276,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8483570,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 521,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 277,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -6,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483678,
+                "shootingPlayerId": 8482874,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 33,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:41",
+            "timeRemaining": "19:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 278,
+            "details": {
+                "reason": "referee-or-linesman",
+                "secondaryReason": "player-injury"
+            }
+        },
+        {
+            "eventId": 522,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:41",
+            "timeRemaining": "19:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 280,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8485385,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 525,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:08",
+            "timeRemaining": "18:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 281,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 10,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 34,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:10",
+            "timeRemaining": "18:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 284,
+            "details": {
+                "reason": "referee-or-linesman"
+            }
+        },
+        {
+            "eventId": 527,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:10",
+            "timeRemaining": "18:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 287,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484168,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 536,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 288,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 12,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480947
+            }
+        },
+        {
+            "eventId": 254,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:39",
+            "timeRemaining": "18:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 289,
+            "details": {
+                "xCoord": -63,
+                "yCoord": -26,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8483684,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 11,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 35,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:40",
+            "timeRemaining": "18:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 290,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 532,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:40",
+            "timeRemaining": "18:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 293,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8482691,
+                "winningPlayerId": 8483012,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 537,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:44",
+            "timeRemaining": "18:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 294,
+            "details": {
+                "xCoord": -81,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483442,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 12,
+                "homeSOG": 8
+            }
+        },
+        {
+            "eventId": 255,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:46",
+            "timeRemaining": "18:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 295,
+            "details": {
+                "xCoord": -76,
+                "yCoord": -12,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483012,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 538,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:51",
+            "timeRemaining": "18:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 296,
+            "details": {
+                "xCoord": -76,
+                "yCoord": 15,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480058,
+                "shootingPlayerId": 8483442,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 548,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:55",
+            "timeRemaining": "18:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 297,
+            "details": {
+                "xCoord": -71,
+                "yCoord": -41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482918,
+                "hitteePlayerId": 8484162
+            }
+        },
+        {
+            "eventId": 601,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:12",
+            "timeRemaining": "17:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 300,
+            "details": {
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 545,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:15",
+            "timeRemaining": "17:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 301,
+            "details": {
+                "xCoord": 93,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "holding",
+                "duration": 2,
+                "committedByPlayerId": 8482691,
+                "drawnByPlayerId": 8484162,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 540,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:15",
+            "timeRemaining": "17:45",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 305,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480012,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 554,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 306,
+            "details": {
+                "xCoord": -30,
+                "yCoord": -34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8477919
+            }
+        },
+        {
+            "eventId": 552,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:56",
+            "timeRemaining": "17:04",
+            "situationCode": "1541",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 310,
+            "details": {
+                "xCoord": -72,
+                "yCoord": 8,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479425,
+                "shootingPlayerId": 8477919,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 576,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:15",
+            "timeRemaining": "15:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 322,
+            "details": {
+                "xCoord": -75,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8483678
+            }
+        },
+        {
+            "eventId": 566,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:22",
+            "timeRemaining": "15:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 325,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "reason": "hit-crossbar",
+                "shotType": "snap",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 36,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:25",
+            "timeRemaining": "15:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 326,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 568,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:25",
+            "timeRemaining": "15:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 329,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8480012,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 256,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:37",
+            "timeRemaining": "15:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 330,
+            "details": {
+                "xCoord": -54,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "slap",
+                "shootingPlayerId": 8479985,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 574,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:03",
+            "timeRemaining": "14:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 333,
+            "details": {
+                "xCoord": 48,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 12,
+                "homeSOG": 9
+            }
+        },
+        {
+            "eventId": 575,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:13",
+            "timeRemaining": "14:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 334,
+            "details": {
+                "xCoord": 82,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480012,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 12,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 583,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:33",
+            "timeRemaining": "14:27",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 342,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8484408,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 585,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:40",
+            "timeRemaining": "14:20",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 343,
+            "details": {
+                "xCoord": 45,
+                "yCoord": -14,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484800,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 598,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:44",
+            "timeRemaining": "14:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 345,
+            "details": {
+                "xCoord": 63,
+                "yCoord": 41,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482858,
+                "hitteePlayerId": 8482691
+            }
+        },
+        {
+            "eventId": 588,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:04",
+            "timeRemaining": "13:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 347,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8484168,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 13,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 654,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:14",
+            "timeRemaining": "13:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 351,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -10,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484240,
+                "hitteePlayerId": 8482866
+            }
+        },
+        {
+            "eventId": 653,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:45",
+            "timeRemaining": "13:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 354,
+            "details": {
+                "xCoord": 1,
+                "yCoord": -1,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480833
+            }
+        },
+        {
+            "eventId": 257,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:54",
+            "timeRemaining": "13:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 358,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480058,
+                "shootingPlayerId": 8483570,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 597,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:00",
+            "timeRemaining": "13:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 359,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "scoringPlayerId": 8483684,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8482751,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8483570,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 55,
+                "goalieInNetId": 8480947,
+                "awayScore": 2,
+                "homeScore": 0,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-jugnauth-scores-goal-against-kevin-lankinen-6380172950112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-jugnauth-marque-un-but-contre-kevin-lankinen-6380173443112",
+                "highlightClip": 6380172950112,
+                "highlightClipFr": 6380173443112,
+                "discreteClip": 6380172260112,
+                "discreteClipFr": 6380171098112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010043/ev597.json"
+        },
+        {
+            "eventId": 599,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:00",
+            "timeRemaining": "13:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 362,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8485385,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 656,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:37",
+            "timeRemaining": "12:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 364,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 15,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8481789,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 14,
+                "homeSOG": 10
+            }
+        },
+        {
+            "eventId": 37,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:38",
+            "timeRemaining": "12:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 365,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 657,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:38",
+            "timeRemaining": "12:22",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 368,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480012,
+                "winningPlayerId": 8483570,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 38,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:46",
+            "timeRemaining": "12:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 369,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 661,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:46",
+            "timeRemaining": "12:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 370,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8480012,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 673,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:10",
+            "timeRemaining": "10:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 381,
+            "details": {
+                "xCoord": 83,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "scoringPlayerId": 8485385,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8483476,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8483467,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8476899,
+                "awayScore": 2,
+                "homeScore": 1,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-cootes-scores-goal-against-matt-murray-6380172548112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-lekkerimaki-marque-un-but-contre-matt-murray-6380170590112",
+                "highlightClip": 6380172548112,
+                "highlightClipFr": 6380170590112,
+                "discreteClip": 6380170807112,
+                "discreteClipFr": 6380173848112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010043/ev673.json"
+        },
+        {
+            "eventId": 679,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:10",
+            "timeRemaining": "10:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 383,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8475169,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 680,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:27",
+            "timeRemaining": "10:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 384,
+            "details": {
+                "xCoord": 62,
+                "yCoord": 0,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484162,
+                "shootingPlayerId": 8483476,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 686,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:31",
+            "timeRemaining": "10:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 385,
+            "details": {
+                "xCoord": 39,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 39,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:41",
+            "timeRemaining": "10:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 387,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 682,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:41",
+            "timeRemaining": "10:19",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 390,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8477919,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 687,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:04",
+            "timeRemaining": "09:56",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 391,
+            "details": {
+                "xCoord": 83,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 11
+            }
+        },
+        {
+            "eventId": 40,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:43",
+            "timeRemaining": "09:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 398,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 694,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:43",
+            "timeRemaining": "09:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 400,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8480012,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 697,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:07",
+            "timeRemaining": "08:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 401,
+            "details": {
+                "xCoord": 46,
+                "yCoord": 10,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 12
+            }
+        },
+        {
+            "eventId": 41,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 402,
+            "details": {
+                "reason": "goalie-stopped-after-sog",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 698,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 405,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8480012,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 752,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:18",
+            "timeRemaining": "08:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 406,
+            "details": {
+                "xCoord": 47,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 13
+            }
+        },
+        {
+            "eventId": 42,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:26",
+            "timeRemaining": "08:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 407,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 753,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:26",
+            "timeRemaining": "08:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 409,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8480012,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 762,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:30",
+            "timeRemaining": "08:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 410,
+            "details": {
+                "xCoord": 81,
+                "yCoord": 39,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479985
+            }
+        },
+        {
+            "eventId": 756,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:34",
+            "timeRemaining": "08:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 411,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8478444,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 757,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:52",
+            "timeRemaining": "08:08",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 412,
+            "details": {
+                "xCoord": 54,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8479425,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 14,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 44,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:54",
+            "timeRemaining": "08:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 413,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 758,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:54",
+            "timeRemaining": "08:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 416,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8478498,
+                "winningPlayerId": 8477919,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 258,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:51",
+            "timeRemaining": "07:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 417,
+            "details": {
+                "xCoord": -57,
+                "yCoord": 36,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484162,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 15,
+                "homeSOG": 14
+            }
+        },
+        {
+            "eventId": 45,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:53",
+            "timeRemaining": "07:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 418,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 763,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:53",
+            "timeRemaining": "07:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 421,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8480833,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 767,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 422,
+            "details": {
+                "xCoord": 13,
+                "yCoord": 17,
+                "zoneCode": "N",
+                "shotType": "snap",
+                "shootingPlayerId": 8480748,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 15,
+                "homeSOG": 15
+            }
+        },
+        {
+            "eventId": 777,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:21",
+            "timeRemaining": "06:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 424,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -27,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480833,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 769,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:28",
+            "timeRemaining": "06:32",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 425,
+            "details": {
+                "xCoord": 34,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480058,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 15,
+                "homeSOG": 16
+            }
+        },
+        {
+            "eventId": 46,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:30",
+            "timeRemaining": "06:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 426,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 770,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:30",
+            "timeRemaining": "06:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 429,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8482691,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 774,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:36",
+            "timeRemaining": "06:24",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 430,
+            "details": {
+                "xCoord": 75,
+                "yCoord": -19,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 15,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 775,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:45",
+            "timeRemaining": "06:15",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 431,
+            "details": {
+                "xCoord": 64,
+                "yCoord": 24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8479985,
+                "shootingPlayerId": 8482918,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 776,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:58",
+            "timeRemaining": "06:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 432,
+            "details": {
+                "xCoord": 78,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484408,
+                "shootingPlayerId": 8482918,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 797,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:10",
+            "timeRemaining": "05:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 433,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 22,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482691,
+                "hitteePlayerId": 8479324
+            }
+        },
+        {
+            "eventId": 809,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:12",
+            "timeRemaining": "05:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 434,
+            "details": {
+                "xCoord": 62,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482918,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 813,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:47",
+            "timeRemaining": "05:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 444,
+            "details": {
+                "xCoord": -89,
+                "yCoord": 34,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483467,
+                "hitteePlayerId": 8482874
+            }
+        },
+        {
+            "eventId": 814,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:51",
+            "timeRemaining": "05:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 446,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480012,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 259,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:05",
+            "timeRemaining": "04:55",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 447,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8482858,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 16,
+                "homeSOG": 17
+            }
+        },
+        {
+            "eventId": 798,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:44",
+            "timeRemaining": "04:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 456,
+            "details": {
+                "xCoord": -62,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483012,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 260,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:47",
+            "timeRemaining": "04:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 457,
+            "details": {
+                "xCoord": -67,
+                "yCoord": 16,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483678,
+                "shootingPlayerId": 8482866,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 810,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:14",
+            "timeRemaining": "03:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 463,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 14,
+                "zoneCode": "O",
+                "playerId": 8483497,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 817,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:17",
+            "timeRemaining": "03:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 465,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 47,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:35",
+            "timeRemaining": "03:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 468,
+            "details": {
+                "reason": "puck-in-benches",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 807,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:35",
+            "timeRemaining": "03:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 471,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484168,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 835,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:26",
+            "timeRemaining": "02:34",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 476,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8483497,
+                "hitteePlayerId": 8480058
+            }
+        },
+        {
+            "eventId": 854,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:47",
+            "timeRemaining": "02:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 482,
+            "details": {
+                "xCoord": 98,
+                "yCoord": 11,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8478498
+            }
+        },
+        {
+            "eventId": 855,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:53",
+            "timeRemaining": "02:07",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 483,
+            "details": {
+                "xCoord": -41,
+                "yCoord": -40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8479425,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 826,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:06",
+            "timeRemaining": "01:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 484,
+            "details": {
+                "xCoord": -61,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478444,
+                "shootingPlayerId": 8482866,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 836,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:50",
+            "timeRemaining": "01:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 492,
+            "details": {
+                "xCoord": 80,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 16,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 839,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:54",
+            "timeRemaining": "01:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 495,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 1,
+                "zoneCode": "O",
+                "blockingPlayerId": 8475169,
+                "shootingPlayerId": 8483467,
+                "eventOwnerTeamId": 23,
+                "reason": "teammate-blocked"
+            }
+        },
+        {
+            "eventId": 844,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:21",
+            "timeRemaining": "00:39",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 500,
+            "details": {
+                "xCoord": 70,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8484162,
+                "shootingPlayerId": 8483467,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 856,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:34",
+            "timeRemaining": "00:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 503,
+            "details": {
+                "xCoord": 88,
+                "yCoord": 34,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8482918,
+                "hitteePlayerId": 8484162
+            }
+        },
+        {
+            "eventId": 847,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:39",
+            "timeRemaining": "00:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 504,
+            "details": {
+                "xCoord": 66,
+                "yCoord": -10,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483684,
+                "shootingPlayerId": 8483678,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 848,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:43",
+            "timeRemaining": "00:17",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 505,
+            "details": {
+                "xCoord": 52,
+                "yCoord": 26,
+                "zoneCode": "D",
+                "blockingPlayerId": 8478477,
+                "shootingPlayerId": 8482691,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 261,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 507,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478477,
+                "goalieInNetId": 8480947,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 17,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 48,
+            "periodDescriptor": {
+                "number": 2,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "left",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 510
+        },
+        {
+            "eventId": 860,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 520,
+            "typeDescKey": "period-start",
+            "sortOrder": 516
+        },
+        {
+            "eventId": 859,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:00",
+            "timeRemaining": "20:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 518,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480012,
+                "winningPlayerId": 8477919,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 867,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:14",
+            "timeRemaining": "19:46",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 519,
+            "details": {
+                "xCoord": 53,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480800,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 868,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:19",
+            "timeRemaining": "19:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 520,
+            "details": {
+                "xCoord": 85,
+                "yCoord": 36,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480012,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 302,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:35",
+            "timeRemaining": "19:25",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 522,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -13,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 862,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 523,
+            "details": {
+                "xCoord": -42,
+                "yCoord": 7,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "scoringPlayerId": 8479425,
+                "scoringPlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8476899,
+                "awayScore": 2,
+                "homeScore": 2,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-hronek-scores-goal-against-matt-murray-6380173988112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-hronek-marque-un-but-contre-matt-murray-6380174779112",
+                "highlightClip": 6380173988112,
+                "highlightClipFr": 6380174779112,
+                "discreteClip": 6380174977112,
+                "discreteClipFr": 6380175062112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010043/ev862.json"
+        },
+        {
+            "eventId": 863,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:39",
+            "timeRemaining": "19:21",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 526,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8485385,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 872,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:44",
+            "timeRemaining": "19:16",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 527,
+            "details": {
+                "xCoord": 63,
+                "yCoord": -40,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8483467
+            }
+        },
+        {
+            "eventId": 453,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:50",
+            "timeRemaining": "19:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 528,
+            "details": {
+                "reason": "icing"
+            }
+        },
+        {
+            "eventId": 869,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "00:50",
+            "timeRemaining": "19:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 529,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8485385,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 303,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:00",
+            "timeRemaining": "19:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 531,
+            "details": {
+                "xCoord": -69,
+                "yCoord": -4,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483476,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 873,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:22",
+            "timeRemaining": "18:38",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 532,
+            "details": {
+                "xCoord": 50,
+                "yCoord": -35,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482866,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 18,
+                "homeSOG": 18
+            }
+        },
+        {
+            "eventId": 455,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:23",
+            "timeRemaining": "18:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 533,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 874,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:23",
+            "timeRemaining": "18:37",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 536,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8484168,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 878,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:30",
+            "timeRemaining": "18:30",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 537,
+            "details": {
+                "xCoord": -51,
+                "yCoord": -22,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484408,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 18,
+                "homeSOG": 19
+            }
+        },
+        {
+            "eventId": 889,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "01:34",
+            "timeRemaining": "18:26",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 538,
+            "details": {
+                "xCoord": -44,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8484168
+            }
+        },
+        {
+            "eventId": 896,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:01",
+            "timeRemaining": "17:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 542,
+            "details": {
+                "xCoord": 76,
+                "yCoord": 40,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484408,
+                "hitteePlayerId": 8483497
+            }
+        },
+        {
+            "eventId": 456,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:19",
+            "timeRemaining": "17:41",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 535,
+            "typeDescKey": "delayed-penalty",
+            "sortOrder": 545,
+            "details": {
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 892,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1560",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 548,
+            "details": {
+                "xCoord": -38,
+                "yCoord": -18,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "slashing",
+                "duration": 2,
+                "committedByPlayerId": 8479324,
+                "drawnByPlayerId": 8480800,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 887,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:34",
+            "timeRemaining": "17:26",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 552,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480012,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 895,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:44",
+            "timeRemaining": "17:16",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 553,
+            "details": {
+                "xCoord": -66,
+                "yCoord": -18,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8475169,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 18,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 263,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "02:46",
+            "timeRemaining": "17:14",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 554,
+            "details": {
+                "xCoord": -67,
+                "yCoord": -1,
+                "zoneCode": "D",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480009,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 19,
+                "homeSOG": 20
+            }
+        },
+        {
+            "eventId": 897,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:09",
+            "timeRemaining": "16:51",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 555,
+            "details": {
+                "xCoord": -53,
+                "yCoord": 2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8477919,
+                "shootingPlayerId": 8480800,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 898,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:26",
+            "timeRemaining": "16:34",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 556,
+            "details": {
+                "xCoord": -74,
+                "yCoord": -11,
+                "zoneCode": "D",
+                "blockingPlayerId": 8482866,
+                "shootingPlayerId": 8478444,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 899,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:31",
+            "timeRemaining": "16:29",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 557,
+            "details": {
+                "xCoord": -80,
+                "yCoord": -5,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8475169,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 901,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "03:51",
+            "timeRemaining": "16:09",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 559,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -11,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 21
+            }
+        },
+        {
+            "eventId": 902,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:07",
+            "timeRemaining": "15:53",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 560,
+            "details": {
+                "xCoord": -79,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 22
+            }
+        },
+        {
+            "eventId": 903,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:25",
+            "timeRemaining": "15:35",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 561,
+            "details": {
+                "xCoord": -65,
+                "yCoord": -2,
+                "zoneCode": "D",
+                "blockingPlayerId": 8480009,
+                "shootingPlayerId": 8480012,
+                "eventOwnerTeamId": 23,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 304,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:29",
+            "timeRemaining": "15:31",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 562,
+            "details": {
+                "xCoord": -86,
+                "yCoord": 25,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 23
+            }
+        },
+        {
+            "eventId": 457,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:30",
+            "timeRemaining": "15:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 563,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 904,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:30",
+            "timeRemaining": "15:30",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 566,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8484168,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 934,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:32",
+            "timeRemaining": "15:28",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 567,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 30,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8484162
+            }
+        },
+        {
+            "eventId": 912,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "04:56",
+            "timeRemaining": "15:04",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 572,
+            "details": {
+                "xCoord": 69,
+                "yCoord": 13,
+                "zoneCode": "O",
+                "reason": "wide-right",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484168,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 928,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:29",
+            "timeRemaining": "14:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 580,
+            "details": {
+                "xCoord": 10,
+                "yCoord": 15,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8476927
+            }
+        },
+        {
+            "eventId": 939,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "05:58",
+            "timeRemaining": "14:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 587,
+            "details": {
+                "xCoord": 39,
+                "yCoord": -15,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8483442
+            }
+        },
+        {
+            "eventId": 930,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:27",
+            "timeRemaining": "13:33",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 591,
+            "details": {
+                "xCoord": -47,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480800,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 957,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:31",
+            "timeRemaining": "13:29",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 592,
+            "details": {
+                "xCoord": -95,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8482918
+            }
+        },
+        {
+            "eventId": 958,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "06:55",
+            "timeRemaining": "13:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 602,
+            "details": {
+                "xCoord": 18,
+                "yCoord": -40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480012,
+                "hitteePlayerId": 8484800
+            }
+        },
+        {
+            "eventId": 954,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:06",
+            "timeRemaining": "12:54",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 525,
+            "typeDescKey": "takeaway",
+            "sortOrder": 604,
+            "details": {
+                "xCoord": -25,
+                "yCoord": 4,
+                "zoneCode": "O",
+                "playerId": 8480058,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 955,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:08",
+            "timeRemaining": "12:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 605,
+            "details": {
+                "xCoord": 6,
+                "yCoord": 40,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 23,
+                "playerId": 8480058
+            }
+        },
+        {
+            "eventId": 960,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:18",
+            "timeRemaining": "12:42",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 608,
+            "details": {
+                "xCoord": -8,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479985,
+                "hitteePlayerId": 8478498
+            }
+        },
+        {
+            "eventId": 458,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:37",
+            "timeRemaining": "12:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 616,
+            "details": {
+                "reason": "puck-in-benches",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 952,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:37",
+            "timeRemaining": "12:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 618,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8483570,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 959,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:46",
+            "timeRemaining": "12:14",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 619,
+            "details": {
+                "xCoord": 74,
+                "yCoord": 26,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483684,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 974,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:54",
+            "timeRemaining": "12:06",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 620,
+            "details": {
+                "xCoord": 96,
+                "yCoord": 18,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482874,
+                "hitteePlayerId": 8479425
+            }
+        },
+        {
+            "eventId": 975,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "07:58",
+            "timeRemaining": "12:02",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 621,
+            "details": {
+                "xCoord": 57,
+                "yCoord": -41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8481789,
+                "hitteePlayerId": 8475169
+            }
+        },
+        {
+            "eventId": 961,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:12",
+            "timeRemaining": "11:48",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 622,
+            "details": {
+                "xCoord": -43,
+                "yCoord": -20,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8475169,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 24
+            }
+        },
+        {
+            "eventId": 459,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:50",
+            "timeRemaining": "11:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 632,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 972,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "08:50",
+            "timeRemaining": "11:10",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 633,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484168,
+                "xCoord": -69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 995,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:01",
+            "timeRemaining": "10:59",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 634,
+            "details": {
+                "xCoord": -50,
+                "yCoord": -42,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482866,
+                "hitteePlayerId": 8484408
+            }
+        },
+        {
+            "eventId": 1003,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:03",
+            "timeRemaining": "10:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 635,
+            "details": {
+                "xCoord": -94,
+                "yCoord": -28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480748,
+                "hitteePlayerId": 8482858
+            }
+        },
+        {
+            "eventId": 979,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:25",
+            "timeRemaining": "10:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 639,
+            "details": {
+                "xCoord": -17,
+                "yCoord": 17,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "shootingPlayerId": 8476927,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 25
+            }
+        },
+        {
+            "eventId": 305,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:42",
+            "timeRemaining": "10:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 644,
+            "details": {
+                "xCoord": -82,
+                "yCoord": -8,
+                "zoneCode": "O",
+                "shotType": "backhand",
+                "shootingPlayerId": 8482918,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 26
+            }
+        },
+        {
+            "eventId": 984,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:47",
+            "timeRemaining": "10:13",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 507,
+            "typeDescKey": "missed-shot",
+            "sortOrder": 645,
+            "details": {
+                "xCoord": -35,
+                "yCoord": 11,
+                "zoneCode": "O",
+                "reason": "wide-left",
+                "shotType": "wrist",
+                "shootingPlayerId": 8483678,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 985,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:55",
+            "timeRemaining": "10:05",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 646,
+            "details": {
+                "xCoord": -79,
+                "yCoord": -21,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8480833,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 27
+            }
+        },
+        {
+            "eventId": 306,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "09:59",
+            "timeRemaining": "10:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 647,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "snap",
+                "shootingPlayerId": 8480833,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 28
+            }
+        },
+        {
+            "eventId": 307,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:00",
+            "timeRemaining": "10:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 648,
+            "details": {
+                "xCoord": -80,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "shootingPlayerId": 8480833,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 19,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 1002,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "10:15",
+            "timeRemaining": "09:45",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 654,
+            "details": {
+                "xCoord": -87,
+                "yCoord": 28,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "playerId": 8479985
+            }
+        },
+        {
+            "eventId": 1026,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:09",
+            "timeRemaining": "08:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 665,
+            "details": {
+                "xCoord": -98,
+                "yCoord": -16,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8475169,
+                "hitteePlayerId": 8484162
+            }
+        },
+        {
+            "eventId": 1027,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "11:11",
+            "timeRemaining": "08:49",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 666,
+            "details": {
+                "xCoord": -77,
+                "yCoord": -39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8479985
+            }
+        },
+        {
+            "eventId": 1012,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:08",
+            "timeRemaining": "07:52",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 675,
+            "details": {
+                "xCoord": 37,
+                "yCoord": 5,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482874,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 20,
+                "homeSOG": 29
+            }
+        },
+        {
+            "eventId": 461,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 676,
+            "details": {
+                "reason": "goalie-stopped-after-sog"
+            }
+        },
+        {
+            "eventId": 1016,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 677,
+            "details": {
+                "xCoord": 97,
+                "yCoord": -7,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8481789,
+                "drawnByPlayerId": 8483678,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1020,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 679,
+            "details": {
+                "xCoord": 96,
+                "yCoord": -5,
+                "zoneCode": "D",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8483678,
+                "drawnByPlayerId": 8481789,
+                "eventOwnerTeamId": 23
+            }
+        },
+        {
+            "eventId": 1023,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 509,
+            "typeDescKey": "penalty",
+            "sortOrder": 681,
+            "details": {
+                "xCoord": 84,
+                "yCoord": -3,
+                "zoneCode": "O",
+                "typeCode": "MIN",
+                "descKey": "roughing",
+                "duration": 2,
+                "committedByPlayerId": 8482874,
+                "drawnByPlayerId": 8480058,
+                "eventOwnerTeamId": 55
+            }
+        },
+        {
+            "eventId": 1151,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 683,
+            "details": {
+                "reason": "tv-timeout",
+                "secondaryReason": "tv-timeout"
+            }
+        },
+        {
+            "eventId": 1013,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:10",
+            "timeRemaining": "07:50",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 686,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8480012,
+                "xCoord": -69,
+                "yCoord": -22,
+                "zoneCode": "O"
+            }
+        },
+        {
+            "eventId": 308,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:29",
+            "timeRemaining": "07:31",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 687,
+            "details": {
+                "xCoord": -78,
+                "yCoord": -2,
+                "zoneCode": "O",
+                "shotType": "deflected",
+                "shootingPlayerId": 8478498,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 20,
+                "homeSOG": 30
+            }
+        },
+        {
+            "eventId": 152,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:32",
+            "timeRemaining": "07:28",
+            "situationCode": "1451",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 688,
+            "details": {
+                "xCoord": -83,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "poke",
+                "scoringPlayerId": 8478498,
+                "scoringPlayerTotal": 1,
+                "assist1PlayerId": 8478444,
+                "assist1PlayerTotal": 1,
+                "assist2PlayerId": 8480800,
+                "assist2PlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "goalieInNetId": 8476899,
+                "awayScore": 2,
+                "homeScore": 3,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-debrusk-scores-ppg-against-matt-murray-6380173912112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-debrusk-marque-un-but-en-a-n-contre-matt-murray-6380175384112",
+                "highlightClip": 6380173912112,
+                "highlightClipFr": 6380175384112,
+                "discreteClip": 6380173727112,
+                "discreteClipFr": 6380173824112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010043/ev152.json"
+        },
+        {
+            "eventId": 1030,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "12:32",
+            "timeRemaining": "07:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 692,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8476927,
+                "winningPlayerId": 8484168,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1070,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:00",
+            "timeRemaining": "07:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 693,
+            "details": {
+                "xCoord": 94,
+                "yCoord": 28,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8476927
+            }
+        },
+        {
+            "eventId": 1080,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:13",
+            "timeRemaining": "06:47",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 696,
+            "details": {
+                "xCoord": -98,
+                "yCoord": 1,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8479324,
+                "hitteePlayerId": 8476927
+            }
+        },
+        {
+            "eventId": 1089,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:17",
+            "timeRemaining": "06:43",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 697,
+            "details": {
+                "xCoord": -74,
+                "yCoord": 41,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8484408,
+                "hitteePlayerId": 8482751
+            }
+        },
+        {
+            "eventId": 1097,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:32",
+            "timeRemaining": "06:28",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 705,
+            "details": {
+                "xCoord": 4,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8480009,
+                "hitteePlayerId": 8483467
+            }
+        },
+        {
+            "eventId": 466,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:37",
+            "timeRemaining": "06:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 706,
+            "details": {
+                "reason": "offside"
+            }
+        },
+        {
+            "eventId": 1045,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "13:37",
+            "timeRemaining": "06:23",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 707,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8485385,
+                "winningPlayerId": 8477919,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1108,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:03",
+            "timeRemaining": "05:57",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 711,
+            "details": {
+                "xCoord": -94,
+                "yCoord": 29,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8484800,
+                "hitteePlayerId": 8485385
+            }
+        },
+        {
+            "eventId": 1050,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:09",
+            "timeRemaining": "05:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 712,
+            "details": {
+                "xCoord": -72,
+                "yCoord": -1,
+                "zoneCode": "O",
+                "shotType": "tip-in",
+                "shootingPlayerId": 8485385,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 20,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 1052,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:20",
+            "timeRemaining": "05:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 715,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -17,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8484162,
+                "goalieInNetId": 8484268,
+                "eventOwnerTeamId": 55,
+                "awaySOG": 21,
+                "homeSOG": 31
+            }
+        },
+        {
+            "eventId": 1061,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "14:57",
+            "timeRemaining": "05:03",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 722,
+            "details": {
+                "xCoord": -27,
+                "yCoord": 3,
+                "zoneCode": "O",
+                "shotType": "wrist",
+                "shootingPlayerId": 8482691,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 21,
+                "homeSOG": 32
+            }
+        },
+        {
+            "eventId": 1118,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:42",
+            "timeRemaining": "04:18",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 731,
+            "details": {
+                "xCoord": 78,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "hittingPlayerId": 8482751,
+                "hitteePlayerId": 8484240
+            }
+        },
+        {
+            "eventId": 1078,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "15:59",
+            "timeRemaining": "04:01",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 506,
+            "typeDescKey": "shot-on-goal",
+            "sortOrder": 739,
+            "details": {
+                "xCoord": -50,
+                "yCoord": -30,
+                "zoneCode": "O",
+                "shotType": "slap",
+                "shootingPlayerId": 8476927,
+                "goalieInNetId": 8476899,
+                "eventOwnerTeamId": 23,
+                "awaySOG": 21,
+                "homeSOG": 33
+            }
+        },
+        {
+            "eventId": 1130,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "16:24",
+            "timeRemaining": "03:36",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 741,
+            "details": {
+                "xCoord": -83,
+                "yCoord": 39,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8476927,
+                "hitteePlayerId": 8478477
+            }
+        },
+        {
+            "eventId": 1092,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "17:20",
+            "timeRemaining": "02:40",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 752,
+            "details": {
+                "xCoord": 53,
+                "yCoord": -24,
+                "zoneCode": "D",
+                "blockingPlayerId": 8475169,
+                "shootingPlayerId": 8484162,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 467,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:00",
+            "timeRemaining": "02:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 761,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 1100,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:00",
+            "timeRemaining": "02:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 766,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8477919,
+                "winningPlayerId": 8475169,
+                "xCoord": 20,
+                "yCoord": -22,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 1135,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:09",
+            "timeRemaining": "01:51",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 767,
+            "details": {
+                "xCoord": -97,
+                "yCoord": 21,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8483476,
+                "hitteePlayerId": 8483684
+            }
+        },
+        {
+            "eventId": 153,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:49",
+            "timeRemaining": "01:11",
+            "situationCode": "0651",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 505,
+            "typeDescKey": "goal",
+            "sortOrder": 771,
+            "details": {
+                "xCoord": 13,
+                "yCoord": -41,
+                "zoneCode": "N",
+                "shotType": "wrist",
+                "scoringPlayerId": 8475169,
+                "scoringPlayerTotal": 1,
+                "eventOwnerTeamId": 23,
+                "awayScore": 2,
+                "homeScore": 4,
+                "highlightClipSharingUrl": "https://nhl.com/video/sea-van-kane-scores-empty-net-goal-6380174491112",
+                "highlightClipSharingUrlFr": "https://nhl.com/fr/video/sea-van-kane-van-marque-un-but-dans-un-filet-desert-6380175080112",
+                "highlightClip": 6380174491112,
+                "highlightClipFr": 6380175080112,
+                "discreteClip": 6380174302112,
+                "discreteClipFr": 6380174301112
+            },
+            "pptReplayUrl": "https://wsr.nhle.com/sprites/20252026/2025010043/ev153.json"
+        },
+        {
+            "eventId": 1112,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "18:49",
+            "timeRemaining": "01:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 774,
+            "details": {
+                "eventOwnerTeamId": 55,
+                "losingPlayerId": 8480748,
+                "winningPlayerId": 8483012,
+                "xCoord": 0,
+                "yCoord": 0,
+                "zoneCode": "N"
+            }
+        },
+        {
+            "eventId": 468,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:07",
+            "timeRemaining": "00:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 775,
+            "details": {
+                "reason": "puck-in-benches"
+            }
+        },
+        {
+            "eventId": 1116,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:07",
+            "timeRemaining": "00:53",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 776,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483012,
+                "winningPlayerId": 8476927,
+                "xCoord": 69,
+                "yCoord": 22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 1136,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:25",
+            "timeRemaining": "00:35",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 503,
+            "typeDescKey": "hit",
+            "sortOrder": 777,
+            "details": {
+                "xCoord": 93,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "eventOwnerTeamId": 23,
+                "hittingPlayerId": 8480058,
+                "hitteePlayerId": 8483442
+            }
+        },
+        {
+            "eventId": 1132,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:29",
+            "timeRemaining": "00:31",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 778,
+            "details": {
+                "xCoord": 38,
+                "yCoord": -38,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 55,
+                "playerId": 8478477
+            }
+        },
+        {
+            "eventId": 1134,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:48",
+            "timeRemaining": "00:12",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 504,
+            "typeDescKey": "giveaway",
+            "sortOrder": 787,
+            "details": {
+                "xCoord": 95,
+                "yCoord": 6,
+                "zoneCode": "O",
+                "eventOwnerTeamId": 23,
+                "playerId": 8484268
+            }
+        },
+        {
+            "eventId": 1127,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:49",
+            "timeRemaining": "00:11",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 508,
+            "typeDescKey": "blocked-shot",
+            "sortOrder": 788,
+            "details": {
+                "xCoord": 77,
+                "yCoord": -26,
+                "zoneCode": "D",
+                "blockingPlayerId": 8483467,
+                "shootingPlayerId": 8481789,
+                "eventOwnerTeamId": 55,
+                "reason": "blocked"
+            }
+        },
+        {
+            "eventId": 469,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:51",
+            "timeRemaining": "00:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 516,
+            "typeDescKey": "stoppage",
+            "sortOrder": 789,
+            "details": {
+                "reason": "puck-in-netting"
+            }
+        },
+        {
+            "eventId": 1128,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "19:51",
+            "timeRemaining": "00:09",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 502,
+            "typeDescKey": "faceoff",
+            "sortOrder": 791,
+            "details": {
+                "eventOwnerTeamId": 23,
+                "losingPlayerId": 8483570,
+                "winningPlayerId": 8482691,
+                "xCoord": 69,
+                "yCoord": -22,
+                "zoneCode": "D"
+            }
+        },
+        {
+            "eventId": 470,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 521,
+            "typeDescKey": "period-end",
+            "sortOrder": 792
+        },
+        {
+            "eventId": 474,
+            "periodDescriptor": {
+                "number": 3,
+                "periodType": "REG",
+                "maxRegulationPeriods": 3
+            },
+            "timeInPeriod": "20:00",
+            "timeRemaining": "00:00",
+            "situationCode": "1551",
+            "homeTeamDefendingSide": "right",
+            "typeCode": 524,
+            "typeDescKey": "game-end",
+            "sortOrder": 796
+        }
+    ],
+    "rosterSpots": [
+        {
+            "teamId": 23,
+            "playerId": 8475169,
+            "firstName": {
+                "default": "Evander"
+            },
+            "lastName": {
+                "default": "Kane"
+            },
+            "sweaterNumber": 91,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8475169.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8475831,
+            "firstName": {
+                "default": "Philipp"
+            },
+            "lastName": {
+                "default": "Grubauer"
+            },
+            "sweaterNumber": 31,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8475831.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8476899,
+            "firstName": {
+                "default": "Matt"
+            },
+            "lastName": {
+                "default": "Murray"
+            },
+            "sweaterNumber": 30,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8476899.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8476927,
+            "firstName": {
+                "default": "Teddy",
+                "cs": "Theodors",
+                "sk": "Theodors"
+            },
+            "lastName": {
+                "default": "Blueger",
+                "cs": "Blugers",
+                "sk": "Blugers"
+            },
+            "sweaterNumber": 53,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8476927.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8477919,
+            "firstName": {
+                "default": "Frederick"
+            },
+            "lastName": {
+                "default": "Gaudreau"
+            },
+            "sweaterNumber": 89,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8477919.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478444,
+            "firstName": {
+                "default": "Brock"
+            },
+            "lastName": {
+                "default": "Boeser"
+            },
+            "sweaterNumber": 6,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8478444.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8478477,
+            "firstName": {
+                "default": "Mitchell"
+            },
+            "lastName": {
+                "default": "Stephens"
+            },
+            "sweaterNumber": 67,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8478477.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8478498,
+            "firstName": {
+                "default": "Jake"
+            },
+            "lastName": {
+                "default": "DeBrusk"
+            },
+            "sweaterNumber": 74,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8478498.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479324,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Lindgren"
+            },
+            "sweaterNumber": 55,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8479324.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8479425,
+            "firstName": {
+                "default": "Filip"
+            },
+            "lastName": {
+                "default": "Hronek"
+            },
+            "sweaterNumber": 17,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8479425.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8479985,
+            "firstName": {
+                "default": "Cale"
+            },
+            "lastName": {
+                "default": "Fleury"
+            },
+            "sweaterNumber": 8,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8479985.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8480009,
+            "firstName": {
+                "default": "Eeli"
+            },
+            "lastName": {
+                "default": "Tolvanen"
+            },
+            "sweaterNumber": 20,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8480009.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480012,
+            "firstName": {
+                "default": "Elias"
+            },
+            "lastName": {
+                "default": "Pettersson"
+            },
+            "sweaterNumber": 40,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480012.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480058,
+            "firstName": {
+                "default": "P.O",
+                "cs": "Pierre-Olivier",
+                "de": "Pierre-Olivier",
+                "es": "Pierre-Olivier",
+                "fi": "Pierre-Olivier",
+                "sk": "Pierre-Olivier",
+                "sv": "Pierre-Olivier"
+            },
+            "lastName": {
+                "default": "Joseph"
+            },
+            "sweaterNumber": 7,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480058.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480748,
+            "firstName": {
+                "default": "Kiefer"
+            },
+            "lastName": {
+                "default": "Sherwood"
+            },
+            "sweaterNumber": 44,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480748.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480800,
+            "firstName": {
+                "default": "Quinn"
+            },
+            "lastName": {
+                "default": "Hughes"
+            },
+            "sweaterNumber": 43,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480800.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480833,
+            "firstName": {
+                "default": "Vitali",
+                "cs": "Vitalij",
+                "sk": "Vitalij"
+            },
+            "lastName": {
+                "default": "Kravtsov",
+                "cs": "Kravcov",
+                "sk": "Kravcov"
+            },
+            "sweaterNumber": 92,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480833.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8480947,
+            "firstName": {
+                "default": "Kevin"
+            },
+            "lastName": {
+                "default": "Lankinen"
+            },
+            "sweaterNumber": 32,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8480947.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8481789,
+            "firstName": {
+                "default": "Tye"
+            },
+            "lastName": {
+                "default": "Kartye"
+            },
+            "sweaterNumber": 12,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8481789.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482691,
+            "firstName": {
+                "default": "Aatu"
+            },
+            "lastName": {
+                "default": "Raty",
+                "cs": "R\u00e4ty",
+                "fi": "R\u00e4ty",
+                "sk": "R\u00e4ty",
+                "sv": "R\u00e4ty"
+            },
+            "sweaterNumber": 54,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482691.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482751,
+            "firstName": {
+                "default": "Ryan"
+            },
+            "lastName": {
+                "default": "Winterton"
+            },
+            "sweaterNumber": 26,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482751.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482858,
+            "firstName": {
+                "default": "Ryker"
+            },
+            "lastName": {
+                "default": "Evans"
+            },
+            "sweaterNumber": 41,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482858.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482866,
+            "firstName": {
+                "default": "Ville"
+            },
+            "lastName": {
+                "default": "Ottavainen"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482866.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8482874,
+            "firstName": {
+                "default": "Jacob"
+            },
+            "lastName": {
+                "default": "Melanson"
+            },
+            "sweaterNumber": 63,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8482874.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8482918,
+            "firstName": {
+                "default": "Danila"
+            },
+            "lastName": {
+                "default": "Klimovich"
+            },
+            "sweaterNumber": 9,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8482918.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483012,
+            "firstName": {
+                "default": "Logan"
+            },
+            "lastName": {
+                "default": "Morrison"
+            },
+            "sweaterNumber": 96,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483012.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483442,
+            "firstName": {
+                "default": "Jagger"
+            },
+            "lastName": {
+                "default": "Firkus"
+            },
+            "sweaterNumber": 57,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483442.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483467,
+            "firstName": {
+                "default": "Kirill"
+            },
+            "lastName": {
+                "default": "Kudryavtsev"
+            },
+            "sweaterNumber": 59,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483467.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483476,
+            "firstName": {
+                "default": "Jonathan"
+            },
+            "lastName": {
+                "default": "Lekkerim\u00e4ki"
+            },
+            "sweaterNumber": 23,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483476.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483497,
+            "firstName": {
+                "default": "Jani"
+            },
+            "lastName": {
+                "default": "Nyman"
+            },
+            "sweaterNumber": 38,
+            "positionCode": "R",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483497.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483570,
+            "firstName": {
+                "default": "Ben"
+            },
+            "lastName": {
+                "default": "Meyers"
+            },
+            "sweaterNumber": 59,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483570.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8483678,
+            "firstName": {
+                "default": "Elias"
+            },
+            "lastName": {
+                "default": "Pettersson"
+            },
+            "sweaterNumber": 25,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8483678.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8483684,
+            "firstName": {
+                "default": "Tyson"
+            },
+            "lastName": {
+                "default": "Jugnauth"
+            },
+            "sweaterNumber": 83,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8483684.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484162,
+            "firstName": {
+                "default": "Lukas"
+            },
+            "lastName": {
+                "default": "Dragicevic"
+            },
+            "sweaterNumber": 92,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484162.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484168,
+            "firstName": {
+                "default": "Oscar"
+            },
+            "lastName": {
+                "default": "Fisker Molgaard"
+            },
+            "sweaterNumber": 78,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484168.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484240,
+            "firstName": {
+                "default": "Tom"
+            },
+            "lastName": {
+                "default": "Willander"
+            },
+            "sweaterNumber": 5,
+            "positionCode": "D",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484240.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484268,
+            "firstName": {
+                "default": "Nikita"
+            },
+            "lastName": {
+                "default": "Tolopilo"
+            },
+            "sweaterNumber": 60,
+            "positionCode": "G",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484268.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8484408,
+            "firstName": {
+                "default": "Vilmer"
+            },
+            "lastName": {
+                "default": "Alriksson"
+            },
+            "sweaterNumber": 46,
+            "positionCode": "L",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8484408.png"
+        },
+        {
+            "teamId": 55,
+            "playerId": 8484800,
+            "firstName": {
+                "default": "Berkly"
+            },
+            "lastName": {
+                "default": "Catton"
+            },
+            "sweaterNumber": 77,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/SEA/8484800.png"
+        },
+        {
+            "teamId": 23,
+            "playerId": 8485385,
+            "firstName": {
+                "default": "Braeden"
+            },
+            "lastName": {
+                "default": "Cootes"
+            },
+            "sweaterNumber": 80,
+            "positionCode": "C",
+            "headshot": "https://assets.nhle.com/mugs/nhl/20252026/VAN/8485385.png"
+        }
+    ],
+    "regPeriods": 3,
+    "summary": {}
+}

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -106,4 +106,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [PRESEASON GAME #1: Vancouver Canucks vs Seattle Kraken - Seattle wins 5-3](./2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json)
 - [PRESEASON GAME #2: Seattle Kraken vs Calgary Flames - Seattle loses 4-1](./2025-26/preseason/20250923-SEA-vs-CGY-2025010027.json)
 - [PRESEASON GAME #3: Seattle Kraken vs Edmonton Oilers - Seattle wins 4-1](./2025-26/preseason/20250924-SEA-vs-EDM-2025010033.json)
-- [PRESEASON GAME #4: Seattle Kraken vs Vancouver Canucks](./2025-26/preseason/20250926-SEA-vs-VAN-2025010043.json)
+- [PRESEASON GAME #4: Seattle Kraken vs Vancouver Canucks - Seattle loses 4-2](./2025-26/preseason/20250926-SEA-vs-VAN-2025010043.json)

--- a/data/NHL - National Hockey League/README.md
+++ b/data/NHL - National Hockey League/README.md
@@ -106,3 +106,4 @@ Play-by-play data can be accessed via [https://api-web.nhle.com/v1/gamecenter/20
 - [PRESEASON GAME #1: Vancouver Canucks vs Seattle Kraken - Seattle wins 5-3](./2025-26/preseason/20250921-VAN-vs-SEA-2025010011.json)
 - [PRESEASON GAME #2: Seattle Kraken vs Calgary Flames - Seattle loses 4-1](./2025-26/preseason/20250923-SEA-vs-CGY-2025010027.json)
 - [PRESEASON GAME #3: Seattle Kraken vs Edmonton Oilers - Seattle wins 4-1](./2025-26/preseason/20250924-SEA-vs-EDM-2025010033.json)
+- [PRESEASON GAME #4: Seattle Kraken vs Vancouver Canucks](./2025-26/preseason/20250926-SEA-vs-VAN-2025010043.json)


### PR DESCRIPTION
# Description

Added complete NHL preseason game data for the September 26th, 2025 matchup between Seattle Kraken and Vancouver Canucks.

## Changes Made:
- Downloaded and saved NHL preseason game data (20250926-SEA-vs-VAN-2025010043.json)
- Updated NHL README.md with new preseason game entry
- Game ID: 2025010043 from NHL API
- Includes full play-by-play data for analysis

## Game Details:
- **Teams:** Seattle Kraken vs Vancouver Canucks
- **Date:** September 26, 2025
- **Game Type:** NHL Preseason
- **Season:** 2025-26
- **File Location:** data/NHL - National Hockey League/2025-26/preseason/

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally using download script
- [x] NHL game data successfully downloaded and validated
- [x] My commits are signed with GPG