### PR TITLE
feat: add timing to test script execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "download:whl:game": "./src/download_whl_game.sh",
     "download:whl:game:date": "./src/download_whl_game.sh 2025-09-05",
     "download:whl:game:multiple": "./src/download_whl_game.sh 2025-09-02 2025-09-05",
-    "test": "npm run test:workflows && npm run test:nfl:espn",
+    "test": "time (npm run test:workflows && npm run test:nfl:espn)",
     "test:nfl:espn": "chmod +x ./src/test_download_nfl_espn.sh && ./src/test_download_nfl_espn.sh",
     "test:workflows": "chmod +x .github/test-workflows.sh && .github/test-workflows.sh",
     "test:workflows:semantic": "act pull_request -e .github/test-data/pr-events/minor.json -W .github/workflows/semantic-pr-check.yml",


### PR DESCRIPTION
# Description

Added timing capability to the test script to measure execution duration of the entire test suite. The `time` command now wraps the test execution, providing real, user, and system time metrics.

## Type of Change

version: feat     # New feature (minor version bump)

## Changes Made

- Modified the `test` script in `package.json` to wrap execution with `time` command
- Displays real, user, and system time for the entire test suite
- Helps track performance and identify slow tests over time

## Testing

- [x] I have tested these changes locally using `npm run test`
- [x] All existing tests pass
- [x] My commits are signed with GPG

## Example Output

The test suite now displays timing information at the end:
```
real    0m28.162s
user    0m1.802s
sys     0m2.893s
```